### PR TITLE
[JUJU-644] Return better errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ This is the Go function that we are going to call from Lua. Its inputs are:
 It returns the next continuation on success, else an error.
 
 ```golang
-func addints(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func addints(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var x, y rt.Int
 
 	// First check there are two arguments

--- a/examples/extend/main.go
+++ b/examples/extend/main.go
@@ -16,7 +16,7 @@ import (
 //      (the one which receives the values computed by this function).
 //
 // It returns the next continuation on success, else an error.
-func addints(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func addints(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var x, y int64
 
 	// First check there are two arguments

--- a/examples/userdata/regexlib/regexlib.go
+++ b/examples/userdata/regexlib/regexlib.go
@@ -63,7 +63,7 @@ func newRegex(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	re, compErr := regexp.Compile(string(s))
 	if compErr != nil {
-		return nil, rt.NewErrorE(compErr)
+		return nil, compErr
 	}
 	regexMeta := t.Registry(regexMetaKey)
 	return c.PushingNext(t.Runtime, rt.UserDataValue(rt.NewUserData(re, regexMeta.AsTable()))), nil

--- a/examples/userdata/regexlib/regexlib.go
+++ b/examples/userdata/regexlib/regexlib.go
@@ -52,7 +52,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 }
 
 // Creates a new regex userdata from a string.
-func newRegex(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func newRegex(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var s string
 	err := c.Check1Arg()
 	if err == nil {
@@ -80,7 +80,7 @@ func valueToRegex(v rt.Value) (re *regexp.Regexp, ok bool) {
 }
 
 // Helper function that extracts a regexp arg from a continuation.
-func regexArg(c *rt.GoCont, n int) (*regexp.Regexp, *rt.Error) {
+func regexArg(c *rt.GoCont, n int) (*regexp.Regexp, error) {
 	re, ok := valueToRegex(c.Arg(n))
 	if ok {
 		return re, nil
@@ -89,7 +89,7 @@ func regexArg(c *rt.GoCont, n int) (*regexp.Regexp, *rt.Error) {
 }
 
 // This implements the 'find' method of a regexp.
-func regexFind(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func regexFind(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		re *regexp.Regexp
 		s  string
@@ -114,7 +114,7 @@ func regexFind(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 }
 
 // Implementation of the regex's '__tostring' metamethod.
-func regexToString(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func regexToString(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var re *regexp.Regexp
 	err := c.Check1Arg()
 	if err == nil {

--- a/examples/userdata/regexlib/regexlib.go
+++ b/examples/userdata/regexlib/regexlib.go
@@ -85,7 +85,7 @@ func regexArg(c *rt.GoCont, n int) (*regexp.Regexp, error) {
 	if ok {
 		return re, nil
 	}
-	return nil, rt.NewErrorF("#%d must be a regex", n+1)
+	return nil, fmt.Errorf("#%d must be a regex", n+1)
 }
 
 // This implements the 'find' method of a regexp.

--- a/lib/base/assert.go
+++ b/lib/base/assert.go
@@ -2,7 +2,7 @@ package base
 
 import rt "github.com/arnodel/golua/runtime"
 
-func assert(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func assert(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -15,8 +15,7 @@ func assert(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 		} else {
 			msg = etc[0]
 		}
-		err := rt.NewError(msg)
-		err.AddContext(c.Next(), 1)
+		err := rt.NewError(msg).AddContext(c.Next(), 1)
 		return nil, err
 	}
 	next := c.Next()

--- a/lib/base/base.go
+++ b/lib/base/base.go
@@ -65,7 +65,7 @@ func ToString(t *rt.Thread, v rt.Value) (string, error) {
 	if ok {
 		s, ok := next.Get(0).ToString()
 		if !ok {
-			return "", rt.NewErrorS("'__tostring' must return a string")
+			return "", errors.New("'__tostring' must return a string")
 		}
 		return s, nil
 	}

--- a/lib/base/base.go
+++ b/lib/base/base.go
@@ -56,7 +56,7 @@ func Load(r *rt.Runtime) (rt.Value, func()) {
 	return rt.NilValue, nil
 }
 
-func ToString(t *rt.Thread, v rt.Value) (string, *rt.Error) {
+func ToString(t *rt.Thread, v rt.Value) (string, error) {
 	next := rt.NewTerminationWith(t.CurrentCont(), 1, false)
 	err, ok := rt.Metacall(t, v, "__tostring", []rt.Value{v}, next)
 	if err != nil {
@@ -73,7 +73,7 @@ func ToString(t *rt.Thread, v rt.Value) (string, *rt.Error) {
 	return s, nil
 }
 
-func tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/collectgarbage.go
+++ b/lib/base/collectgarbage.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"errors"
 	"runtime"
 	"runtime/debug"
 
@@ -44,7 +45,7 @@ func collectgarbage(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		runtime.ReadMemStats(&stats)
 		t.Push1(next, rt.FloatValue(float64(stats.Alloc)/1024.0))
 	default:
-		return nil, rt.NewErrorS("invalid option")
+		return nil, errors.New("invalid option")
 	}
 	return next, nil
 }

--- a/lib/base/collectgarbage.go
+++ b/lib/base/collectgarbage.go
@@ -10,7 +10,7 @@ import (
 var gcPercent int
 var gcRunning bool
 
-func collectgarbage(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func collectgarbage(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	opt := "collect"
 	if c.NArgs() > 0 {
 		optv, err := c.StringArg(0)

--- a/lib/base/dofile.go
+++ b/lib/base/dofile.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func dofile(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func dofile(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	chunk, chunkName, err := loadChunk(t, c.Args())
 	defer t.ReleaseBytes(len(chunk))
 	if err != nil {

--- a/lib/base/dofile.go
+++ b/lib/base/dofile.go
@@ -8,11 +8,11 @@ func dofile(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	chunk, chunkName, err := loadChunk(t, c.Args())
 	defer t.ReleaseBytes(len(chunk))
 	if err != nil {
-		return nil, rt.NewErrorE(err)
+		return nil, err
 	}
 	clos, err := t.LoadFromSourceOrCode(chunkName, chunk, "bt", rt.TableValue(t.GlobalEnv()), true)
 	if err != nil {
-		return nil, rt.NewErrorE(err)
+		return nil, err
 	}
 	return clos.Continuation(t, c.Next()), nil
 }

--- a/lib/base/error.go
+++ b/lib/base/error.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func errorF(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func errorF(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		err   *rt.Error
 		level int64 = 1
@@ -15,14 +15,14 @@ func errorF(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 		err = rt.NewError(c.Arg(0))
 	}
 	if c.NArgs() >= 2 {
-		var argErr *rt.Error
+		var argErr error
 		level, argErr = c.IntArg(1)
 		if argErr != nil {
 			return nil, argErr
 		}
 	}
 	if level != 1 {
-		err.AddContext(c.Next(), int(level))
+		err = err.AddContext(c.Next(), int(level))
 	}
 	return nil, err
 }

--- a/lib/base/getmetatable.go
+++ b/lib/base/getmetatable.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func getmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func getmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/ipairs.go
+++ b/lib/base/ipairs.go
@@ -2,7 +2,7 @@ package base
 
 import rt "github.com/arnodel/golua/runtime"
 
-func ipairsIteratorF(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ipairsIteratorF(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func ipairsIteratorF(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 
 var ipairsIterator = rt.NewGoFunction(ipairsIteratorF, "ipairsiterator", 2, false)
 
-func ipairs(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ipairs(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/load.go
+++ b/lib/base/load.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"bytes"
+	"errors"
 
 	rt "github.com/arnodel/golua/runtime"
 )
@@ -81,7 +82,7 @@ func load(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			}
 			chunk = buf.Bytes()
 		default:
-			return nil, rt.NewErrorS("#1 must be a string or function")
+			return nil, errors.New("#1 must be a string or function")
 		}
 	}
 	// The chunk is no longer used once we leave this function.

--- a/lib/base/load.go
+++ b/lib/base/load.go
@@ -8,7 +8,7 @@ import (
 
 const maxChunkNameLen = 59
 
-func load(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func load(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/loadfile.go
+++ b/lib/base/loadfile.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func loadfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func loadfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	chunk, chunkName, err := loadChunk(t, c.Args())
 	defer t.ReleaseBytes(len(chunk))
 	if err != nil {

--- a/lib/base/next.go
+++ b/lib/base/next.go
@@ -2,7 +2,7 @@ package base
 
 import rt "github.com/arnodel/golua/runtime"
 
-func next(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func next(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/next.go
+++ b/lib/base/next.go
@@ -1,6 +1,10 @@
 package base
 
-import rt "github.com/arnodel/golua/runtime"
+import (
+	"errors"
+
+	rt "github.com/arnodel/golua/runtime"
+)
 
 func next(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
@@ -17,7 +21,7 @@ func next(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	next := c.Next()
 	nk, nv, ok := tbl.Next(k)
 	if !ok {
-		return nil, rt.NewErrorS("invalid key for 'next'")
+		return nil, errors.New("invalid key for 'next'")
 	}
 	t.Push1(next, nk)
 	if !nk.IsNil() {

--- a/lib/base/pairs.go
+++ b/lib/base/pairs.go
@@ -2,7 +2,7 @@ package base
 
 import rt "github.com/arnodel/golua/runtime"
 
-func pairs(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func pairs(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/pcall.go
+++ b/lib/base/pcall.go
@@ -4,19 +4,19 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func pcall(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	var err *rt.Error
+func pcall(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	var err error
 	if err = c.Check1Arg(); err != nil {
 		return nil, err
 	}
 	next := c.Next()
 	res := rt.NewTerminationWith(c, 0, true)
-	_, err = t.CallContext(rt.RuntimeContextDef{}, func() *rt.Error {
+	_, err = t.CallContext(rt.RuntimeContextDef{}, func() error {
 		return rt.Call(t, c.Arg(0), c.Etc(), res)
 	})
 	if err != nil {
 		t.Push1(next, rt.BoolValue(false))
-		t.Push1(next, err.Value())
+		t.Push1(next, rt.ErrorValue(err))
 	} else {
 		t.Push1(next, rt.BoolValue(true))
 		t.Push(next, res.Etc()...)
@@ -24,8 +24,8 @@ func pcall(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func xpcall(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	var err *rt.Error
+func xpcall(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	var err error
 	if err = c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -41,12 +41,12 @@ func xpcall(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 
 	_, err = t.CallContext(rt.RuntimeContextDef{
 		MessageHandler: msgHandler,
-	}, func() *rt.Error {
+	}, func() error {
 		return rt.Call(t, c.Arg(0), c.Etc(), res)
 	})
 	if err != nil {
 		t.Push1(next, rt.BoolValue(false))
-		t.Push1(next, err.Value())
+		t.Push1(next, rt.ErrorValue(err))
 	} else {
 		t.Push1(next, rt.BoolValue(true))
 		t.Push(next, res.Etc()...)

--- a/lib/base/print.go
+++ b/lib/base/print.go
@@ -2,7 +2,7 @@ package base
 
 import rt "github.com/arnodel/golua/runtime"
 
-func print(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func print(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	err := Print(t, c.Etc())
 	if err != nil {
 		return nil, err
@@ -10,7 +10,7 @@ func print(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.Next(), nil
 }
 
-func Print(t *rt.Thread, args []rt.Value) *rt.Error {
+func Print(t *rt.Thread, args []rt.Value) error {
 	tostring := t.GlobalEnv().Get(rt.StringValue("tostring"))
 	for i, v := range args {
 		if i > 0 {

--- a/lib/base/print.go
+++ b/lib/base/print.go
@@ -1,6 +1,10 @@
 package base
 
-import rt "github.com/arnodel/golua/runtime"
+import (
+	"errors"
+
+	rt "github.com/arnodel/golua/runtime"
+)
 
 func print(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	err := Print(t, c.Etc())
@@ -23,7 +27,7 @@ func Print(t *rt.Thread, args []rt.Value) error {
 		if s, ok := vs.TryString(); ok {
 			t.Stdout.Write([]byte(s))
 		} else {
-			return rt.NewErrorS("tostring must return a string")
+			return errors.New("tostring must return a string")
 		}
 	}
 	t.Stdout.Write([]byte{'\n'})

--- a/lib/base/rawequal.go
+++ b/lib/base/rawequal.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func rawequal(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rawequal(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/base/rawget.go
+++ b/lib/base/rawget.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func rawget(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rawget(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/base/rawlen.go
+++ b/lib/base/rawlen.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"errors"
+
 	rt "github.com/arnodel/golua/runtime"
 )
 
@@ -17,5 +19,5 @@ func rawlen(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		t.Push1(next, rt.IntValue(x.AsTable().Len()))
 		return next, nil
 	}
-	return nil, rt.NewErrorS("#1 must be a string or table")
+	return nil, errors.New("#1 must be a string or table")
 }

--- a/lib/base/rawlen.go
+++ b/lib/base/rawlen.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func rawlen(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rawlen(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/rawset.go
+++ b/lib/base/rawset.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func rawset(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rawset(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(3); err != nil {
 		return nil, err
 	}

--- a/lib/base/rawset.go
+++ b/lib/base/rawset.go
@@ -17,7 +17,7 @@ func rawset(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		return nil, rt.NewErrorS("#2 must not be nil")
 	}
 	if err := t.SetTableCheck(tbl, key, c.Arg(2)); err != nil {
-		return nil, rt.NewErrorE(err)
+		return nil, err
 	}
 	return c.PushingNext1(t.Runtime, c.Arg(0)), nil
 }

--- a/lib/base/rawset.go
+++ b/lib/base/rawset.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"errors"
+
 	rt "github.com/arnodel/golua/runtime"
 )
 
@@ -14,7 +16,7 @@ func rawset(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	key := c.Arg(1)
 	if key.IsNil() {
-		return nil, rt.NewErrorS("#2 must not be nil")
+		return nil, errors.New("#2 must not be nil")
 	}
 	if err := t.SetTableCheck(tbl, key, c.Arg(2)); err != nil {
 		return nil, err

--- a/lib/base/select.go
+++ b/lib/base/select.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func selectF(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func selectF(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/select.go
+++ b/lib/base/select.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"errors"
+
 	rt "github.com/arnodel/golua/runtime"
 )
 
@@ -13,7 +15,7 @@ func selectF(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		var s string
 		s, err = c.StringArg(0)
 		if err != nil || s != "#" {
-			return nil, rt.NewErrorS("#1 must be an integer or '#'")
+			return nil, errors.New("#1 must be an integer or '#'")
 		}
 		return c.PushingNext1(t.Runtime, rt.IntValue(int64(len(c.Etc())))), nil
 	}
@@ -22,7 +24,7 @@ func selectF(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		n += int64(len(etc)) + 1
 	}
 	if n < 1 {
-		return nil, rt.NewErrorS("#1 out of range")
+		return nil, errors.New("#1 out of range")
 	}
 	next := c.Next()
 	if int(n) <= len(etc) {

--- a/lib/base/setmetatable.go
+++ b/lib/base/setmetatable.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"errors"
+
 	rt "github.com/arnodel/golua/runtime"
 )
 
@@ -13,7 +15,7 @@ func setmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		return nil, err
 	}
 	if !rt.RawGet(tbl.Metatable(), rt.StringValue("__metatable")).IsNil() {
-		return nil, rt.NewErrorS("cannot set metatable")
+		return nil, errors.New("cannot set metatable")
 	}
 	if c.Arg(1).IsNil() {
 		tbl.SetMetatable(nil)

--- a/lib/base/setmetatable.go
+++ b/lib/base/setmetatable.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func setmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func setmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/base/tonumber.go
+++ b/lib/base/tonumber.go
@@ -6,7 +6,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func tonumber(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tonumber(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/tonumber.go
+++ b/lib/base/tonumber.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"bytes"
+	"errors"
 
 	rt "github.com/arnodel/golua/runtime"
 )
@@ -27,11 +28,11 @@ func tonumber(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		return nil, err
 	}
 	if base < 2 || base > 36 {
-		return nil, rt.NewErrorS("#2 out of range")
+		return nil, errors.New("#2 out of range")
 	}
 	s, ok := n.TryString()
 	if !ok {
-		return nil, rt.NewErrorS("#1 must be a string")
+		return nil, errors.New("#1 must be a string")
 	}
 	digits := bytes.TrimSpace([]byte(s))
 	if len(digits) == 0 {

--- a/lib/base/type.go
+++ b/lib/base/type.go
@@ -4,7 +4,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func typeString(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func typeString(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/base/warn.go
+++ b/lib/base/warn.go
@@ -2,7 +2,7 @@ package base
 
 import rt "github.com/arnodel/golua/runtime"
 
-func warn(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func warn(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	args := c.Etc()
 	if len(args) == 0 {
 		return nil, rt.NewErrorS("bad argument #1 (value needed)")

--- a/lib/base/warn.go
+++ b/lib/base/warn.go
@@ -1,17 +1,22 @@
 package base
 
-import rt "github.com/arnodel/golua/runtime"
+import (
+	"errors"
+	"fmt"
+
+	rt "github.com/arnodel/golua/runtime"
+)
 
 func warn(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	args := c.Etc()
 	if len(args) == 0 {
-		return nil, rt.NewErrorS("bad argument #1 (value needed)")
+		return nil, errors.New("bad argument #1 (value needed)")
 	}
 	msgs := make([]string, len(args))
 	for i, v := range args {
 		s, ok := v.ToString()
 		if !ok {
-			return nil, rt.NewErrorF("bad argument #%d (string expected)", i+1)
+			return nil, fmt.Errorf("bad argument #%d (string expected)", i+1)
 		}
 		msgs[i] = s
 	}

--- a/lib/coroutine/coroutine.go
+++ b/lib/coroutine/coroutine.go
@@ -1,6 +1,8 @@
 package coroutine
 
 import (
+	"fmt"
+
 	"github.com/arnodel/golua/lib/packagelib"
 	rt "github.com/arnodel/golua/runtime"
 )
@@ -40,7 +42,7 @@ func close(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	ok, err := co.Close(t)
 	if !ok {
-		return nil, rt.NewErrorF("cannot close %s thread", statusString(t, co))
+		return nil, fmt.Errorf("cannot close %s thread", statusString(t, co))
 	}
 	next := c.Next()
 	t.Push1(next, rt.BoolValue(err == nil))

--- a/lib/debuglib/debuglib.go
+++ b/lib/debuglib/debuglib.go
@@ -1,6 +1,7 @@
 package debuglib
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/arnodel/golua/lib/packagelib"
@@ -53,7 +54,7 @@ func getinfo(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		fIdx = 1
 	}
 	if c.NArgs() < 1+fIdx {
-		return nil, rt.NewErrorS("missing argument: f")
+		return nil, errors.New("missing argument: f")
 	}
 	switch arg := c.Arg(fIdx); arg.Type() {
 	case rt.IntType:
@@ -65,10 +66,10 @@ func getinfo(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		var tp rt.NumberType
 		idx, tp = rt.FloatToInt(arg.AsFloat())
 		if tp != rt.IsInt {
-			return nil, rt.NewErrorS("f should be an integer or function")
+			return nil, errors.New("f should be an integer or function")
 		}
 	default:
-		return nil, rt.NewErrorS("f should be an integer or function")
+		return nil, errors.New("f should be an integer or function")
 	}
 	if cont == nil {
 		cont = thread.CurrentCont()
@@ -158,7 +159,7 @@ func upvaluejoin(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	up1 := int(upv1) - 1
 	up2 := int(upv2) - 1
 	if up1 < 0 || up1 >= int(f1.Code.UpvalueCount) || up2 < 0 || up2 >= int(f2.Code.UpvalueCount) {
-		return nil, rt.NewErrorS("Invalid upvalue index")
+		return nil, errors.New("Invalid upvalue index")
 	}
 	f1.Upvalues[up1] = f2.Upvalues[up2]
 	return c.Next(), nil

--- a/lib/debuglib/debuglib.go
+++ b/lib/debuglib/debuglib.go
@@ -35,7 +35,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	return pkgVal, nil
 }
 
-func getinfo(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func getinfo(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func getinfo(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func getupvalue(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func getupvalue(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func getupvalue(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func setupvalue(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func setupvalue(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(3); err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func setupvalue(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func upvaluejoin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func upvaluejoin(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(4); err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func upvaluejoin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.Next(), nil
 }
 
-func upvalueid(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func upvalueid(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -183,8 +183,8 @@ func upvalueid(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.LightUserDataValue(rt.LightUserData{Data: f.Upvalues[up]})), nil
 }
 
-func setmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	var err *rt.Error
+func setmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	var err error
 	if err = c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -200,9 +200,9 @@ func setmetatable(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, v), nil
 }
 
-func gethook(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func gethook(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
-		err    *rt.Error
+		err    error
 		thread = t
 	)
 	if c.NArgs() > 0 {
@@ -229,10 +229,10 @@ func getMaskString(flags rt.DebugHookFlags) string {
 	return b.String()
 }
 
-func sethook(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func sethook(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		argOffset int
-		err       *rt.Error
+		err       error
 		thread    = t
 		hook      rt.Value
 		mask      string
@@ -298,7 +298,7 @@ func sethook(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.Next(), nil
 }
 
-func traceback(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func traceback(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		cont            = t.CurrentCont()
 		msgString       = ""
@@ -323,7 +323,7 @@ func traceback(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 			}
 		}
 		if nArgs > msgIndex+1 {
-			var err *rt.Error
+			var err error
 			level, err = c.IntArg(msgIndex + 1)
 			if err != nil {
 				return nil, err

--- a/lib/golib/golib.go
+++ b/lib/golib/golib.go
@@ -70,7 +70,7 @@ func goValueIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	val, indexErr := goIndex(t, u, c.Arg(1))
 	if indexErr != nil {
-		return nil, rt.NewErrorE(indexErr)
+		return nil, indexErr
 	}
 	return c.PushingNext1(t.Runtime, val), nil
 }
@@ -85,7 +85,7 @@ func goValueSetIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	setIndexErr := goSetIndex(t, u, c.Arg(1), c.Arg(2))
 	if setIndexErr != nil {
-		return nil, rt.NewErrorE(setIndexErr)
+		return nil, setIndexErr
 	}
 	return c.Next(), nil
 }
@@ -100,7 +100,7 @@ func goValueCall(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	res, callErr := goCall(t, u, c.Etc())
 	if callErr != nil {
-		return nil, rt.NewErrorE(callErr)
+		return nil, callErr
 	}
 	return c.PushingNext(t.Runtime, res...), nil
 }

--- a/lib/golib/golib.go
+++ b/lib/golib/golib.go
@@ -119,7 +119,7 @@ func goimport(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	forceBuild := c.NArgs() >= 2 && rt.Truth(c.Arg(1))
 	exports, loadErr := goimports.LoadGoPackage(string(path), pluginsRoot, forceBuild)
 	if loadErr != nil {
-		return nil, rt.NewErrorF("cannot import go package %s: %s", path, loadErr)
+		return nil, fmt.Errorf("cannot import go package %s: %s", path, loadErr)
 	}
 	return c.PushingNext1(t.Runtime, NewGoValue(t.Runtime, exports)), nil
 }

--- a/lib/golib/golib.go
+++ b/lib/golib/golib.go
@@ -49,7 +49,7 @@ func NewGoValue(r *rt.Runtime, x interface{}) rt.Value {
 	return rt.UserDataValue(rt.NewUserData(x, getMeta(r)))
 }
 
-func goValueToString(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func goValueToString(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func goValueToString(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(fmt.Sprintf("%#v", u.Value()))), nil
 }
 
-func goValueIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func goValueIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func goValueIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, val), nil
 }
 
-func goValueSetIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func goValueSetIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(3); err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func goValueSetIndex(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.Next(), nil
 }
 
-func goValueCall(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func goValueCall(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func goValueCall(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext(t.Runtime, res...), nil
 }
 
-func goimport(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func goimport(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if pluginsRoot == "" {
 		return nil, rt.NewError(rt.StringValue("cannot import go packages: plugins root not set"))
 	}

--- a/lib/iolib/file.go
+++ b/lib/iolib/file.go
@@ -114,7 +114,7 @@ func TempFile(r *rt.Runtime) (*File, error) {
 }
 
 // FileArg turns a continuation argument into a *File.
-func FileArg(c *rt.GoCont, n int) (*File, *rt.Error) {
+func FileArg(c *rt.GoCont, n int) (*File, error) {
 	f, ok := ValueToFile(c.Arg(n))
 	if ok {
 		return f, nil

--- a/lib/iolib/file.go
+++ b/lib/iolib/file.go
@@ -3,6 +3,7 @@ package iolib
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -119,7 +120,7 @@ func FileArg(c *rt.GoCont, n int) (*File, error) {
 	if ok {
 		return f, nil
 	}
-	return nil, rt.NewErrorF("#%d must be a file", n+1)
+	return nil, fmt.Errorf("#%d must be a file", n+1)
 }
 
 // ValueToFile turns a lua value to a *File if possible.

--- a/lib/iolib/iolib.go
+++ b/lib/iolib/iolib.go
@@ -211,7 +211,7 @@ func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	case rt.StringType:
 		f, ioErr := OpenFile(t.Runtime, arg.AsString(), "r")
 		if ioErr != nil {
-			return nil, rt.NewErrorE(ioErr)
+			return nil, ioErr
 		}
 		fv = newFileUserData(f, ioData.metatable)
 	case rt.UserDataType:
@@ -240,7 +240,7 @@ func output(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	case rt.StringType:
 		f, ioErr := OpenFile(t.Runtime, arg.AsString(), "w")
 		if ioErr != nil {
-			return nil, rt.NewErrorE(ioErr)
+			return nil, ioErr
 		}
 		fv = newFileUserData(f, ioData.metatable)
 	case rt.UserDataType:
@@ -274,12 +274,12 @@ func iolines(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		var ioErr error
 		f, ioErr = OpenFile(t.Runtime, string(fname), "r")
 		if ioErr != nil {
-			return nil, rt.NewErrorE(ioErr)
+			return nil, ioErr
 		}
 	}
 	readers, fmtErr := getFormatReaders(c.Etc())
 	if fmtErr != nil {
-		return nil, rt.NewErrorE(fmtErr)
+		return nil, fmtErr
 	}
 	return c.PushingNext(t.Runtime, rt.FunctionValue(lines(t.Runtime, f, readers, eofAction))), nil
 }
@@ -294,7 +294,7 @@ func filelines(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	readers, fmtErr := getFormatReaders(c.Etc())
 	if fmtErr != nil {
-		return nil, rt.NewErrorE(fmtErr)
+		return nil, fmtErr
 	}
 
 	return c.PushingNext(t.Runtime, rt.FunctionValue(lines(t.Runtime, f, readers, doNotCloseAtEOF))), nil
@@ -325,7 +325,7 @@ func lines(r *rt.Runtime, f *File, readers []formatReader, flags int) *rt.GoFunc
 				t.Push1(next, rt.NilValue)
 				return next, nil
 			}
-			return nil, rt.NewErrorE(err)
+			return nil, err
 		}
 		return next, nil
 	}
@@ -391,7 +391,7 @@ func write(r *rt.Runtime, vf rt.Value, c *rt.GoCont) (rt.Cont, error) {
 		return nil, rt.NewErrorS("#1 must be a file")
 	}
 	if f.IsClosed() {
-		return nil, rt.NewErrorE(errFileAlreadyClosed)
+		return nil, errFileAlreadyClosed
 	}
 	var err error
 	for _, val := range c.Etc() {
@@ -482,7 +482,7 @@ func filesetvbuf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	bufErr := f.SetWriteBuffer(mode, int(size))
 	if bufErr != nil {
-		return nil, rt.NewErrorE(bufErr)
+		return nil, bufErr
 	}
 	return c.PushingNext1(t.Runtime, rt.BoolValue(true)), nil
 }
@@ -490,7 +490,7 @@ func filesetvbuf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 func tmpfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	f, err := TempFile(t.Runtime)
 	if err != nil {
-		return nil, rt.NewErrorE(err)
+		return nil, err
 	}
 	fv := newFileUserData(f, getIoData(t.Runtime).metatable)
 	return c.PushingNext(t.Runtime, rt.UserDataValue(fv)), nil

--- a/lib/iolib/iolib.go
+++ b/lib/iolib/iolib.go
@@ -1,6 +1,7 @@
 package iolib
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -195,7 +196,7 @@ func fileflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 }
 
 func errFileOrFilename() error {
-	return rt.NewErrorS("#1 must be a file or a filename")
+	return errors.New("#1 must be a file or a filename")
 }
 
 func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
@@ -388,7 +389,7 @@ func filewrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 func write(r *rt.Runtime, vf rt.Value, c *rt.GoCont) (rt.Cont, error) {
 	f, ok := ValueToFile(vf)
 	if !ok {
-		return nil, rt.NewErrorS("#1 must be a file")
+		return nil, errors.New("#1 must be a file")
 	}
 	if f.IsClosed() {
 		return nil, errFileAlreadyClosed
@@ -400,7 +401,7 @@ func write(r *rt.Runtime, vf rt.Value, c *rt.GoCont) (rt.Cont, error) {
 		case rt.IntType:
 		case rt.FloatType:
 		default:
-			return nil, rt.NewErrorS("argument must be a string or a number")
+			return nil, errors.New("argument must be a string or a number")
 		}
 		s, _ := val.ToString()
 		if err = f.WriteString(s); err != nil {
@@ -440,7 +441,7 @@ func fileseek(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		case "end":
 			whence = io.SeekEnd
 		default:
-			return nil, rt.NewErrorS(`#1 must be "cur", "set" or "end"`)
+			return nil, errors.New(`#1 must be "cur", "set" or "end"`)
 		}
 	}
 	if nargs >= 3 {

--- a/lib/iolib/iolib.go
+++ b/lib/iolib/iolib.go
@@ -130,7 +130,7 @@ func (d *ioData) defaultInputFile() *File {
 	return d.defaultInput.Value().(*File)
 }
 
-func pushingNextIoResult(r *rt.Runtime, c *rt.GoCont, ioErr error) (rt.Cont, *rt.Error) {
+func pushingNextIoResult(r *rt.Runtime, c *rt.GoCont, ioErr error) (rt.Cont, error) {
 	next := c.Next()
 	if ioErr != nil {
 		return r.ProcessIoError(next, ioErr)
@@ -139,12 +139,12 @@ func pushingNextIoResult(r *rt.Runtime, c *rt.GoCont, ioErr error) (rt.Cont, *rt
 	return next, nil
 }
 
-func ioclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ioclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var f *File
 	if c.NArgs() == 0 {
 		f = getIoData(t.Runtime).defaultOutputFile()
 	} else {
-		var err *rt.Error
+		var err error
 		f, err = FileArg(c, 0)
 		if err != nil {
 			return nil, err
@@ -153,14 +153,14 @@ func ioclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return pushingNextIoResult(t.Runtime, c, f.Close())
 }
 
-func fileclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func fileclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
 	return ioclose(t, c)
 }
 
-func file__close(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func file__close(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -173,12 +173,12 @@ func file__close(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.Next(), nil
 }
 
-func ioflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ioflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var f *File
 	if c.NArgs() == 0 {
 		f = getIoData(t.Runtime).defaultOutputFile()
 	} else {
-		var err *rt.Error
+		var err error
 		f, err = FileArg(c, 0)
 		if err != nil {
 			return nil, err
@@ -187,18 +187,18 @@ func ioflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return pushingNextIoResult(t.Runtime, c, f.Flush())
 }
 
-func fileflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func fileflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
 	return ioflush(t, c)
 }
 
-func errFileOrFilename() *rt.Error {
+func errFileOrFilename() error {
 	return rt.NewErrorS("#1 must be a file or a filename")
 }
 
-func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	ioData := getIoData(t.Runtime)
 	if c.NArgs() == 0 {
 		return c.PushingNext1(t.Runtime, rt.UserDataValue(ioData.defaultInput)), nil
@@ -227,7 +227,7 @@ func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.UserDataValue(fv)), nil
 }
 
-func output(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func output(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	ioData := getIoData(t.Runtime)
 	if c.NArgs() == 0 {
 		return c.PushingNext1(t.Runtime, rt.UserDataValue(ioData.defaultOutput)), nil
@@ -258,7 +258,7 @@ func output(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.UserDataValue(fv)), nil
 }
 
-func iolines(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func iolines(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		f         *File
 		eofAction = closeAtEOF
@@ -284,7 +284,7 @@ func iolines(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext(t.Runtime, rt.FunctionValue(lines(t.Runtime, f, readers, eofAction))), nil
 }
 
-func filelines(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func filelines(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func lines(r *rt.Runtime, f *File, readers []formatReader, flags int) *rt.GoFunc
 	if len(readers) == 0 {
 		readers = []formatReader{lineReader(false)}
 	}
-	iterator := func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+	iterator := func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		next := c.Next()
 		// if f.closed {
 		// 	return next, nil
@@ -335,7 +335,7 @@ func lines(r *rt.Runtime, f *File, readers []formatReader, flags int) *rt.GoFunc
 
 }
 
-func open(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func open(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func open(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext(t.Runtime, rt.UserDataValue(u)), nil
 }
 
-func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -374,18 +374,18 @@ func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext(t.Runtime, val), nil
 }
 
-func iowrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func iowrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	return write(t.Runtime, rt.UserDataValue(getIoData(t.Runtime).defaultOutput), c)
 }
 
-func filewrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func filewrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
 	return write(t.Runtime, c.Arg(0), c)
 }
 
-func write(r *rt.Runtime, vf rt.Value, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func write(r *rt.Runtime, vf rt.Value, c *rt.GoCont) (rt.Cont, error) {
 	f, ok := ValueToFile(vf)
 	if !ok {
 		return nil, rt.NewErrorS("#1 must be a file")
@@ -416,7 +416,7 @@ func write(r *rt.Runtime, vf rt.Value, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func fileseek(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func fileseek(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func fileseek(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func filesetvbuf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func filesetvbuf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func filesetvbuf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.BoolValue(true)), nil
 }
 
-func tmpfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tmpfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	f, err := TempFile(t.Runtime)
 	if err != nil {
 		return nil, rt.NewErrorE(err)
@@ -496,7 +496,7 @@ func tmpfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext(t.Runtime, rt.UserDataValue(fv)), nil
 }
 
-func tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/iolib/read.go
+++ b/lib/iolib/read.go
@@ -11,7 +11,7 @@ func ioread(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	next := c.Next()
 	readers, fmtErr := getFormatReaders(c.Etc())
 	if fmtErr != nil {
-		return nil, rt.NewErrorE(fmtErr)
+		return nil, fmtErr
 	}
 	ioErr := read(t.Runtime, getIoData(t.Runtime).defaultInputFile(), readers, next)
 	if ioErr != nil && ioErr != io.EOF {
@@ -31,7 +31,7 @@ func fileread(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	next := c.Next()
 	readers, fmtErr := getFormatReaders(c.Etc())
 	if fmtErr != nil {
-		return nil, rt.NewErrorE(fmtErr)
+		return nil, fmtErr
 	}
 	ioErr := read(t.Runtime, f, readers, next)
 	if ioErr != nil && ioErr != io.EOF {

--- a/lib/iolib/read.go
+++ b/lib/iolib/read.go
@@ -7,7 +7,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func ioread(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ioread(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	next := c.Next()
 	readers, fmtErr := getFormatReaders(c.Etc())
 	if fmtErr != nil {
@@ -20,7 +20,7 @@ func ioread(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func fileread(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func fileread(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/mathlib/mathlib.go
+++ b/lib/mathlib/mathlib.go
@@ -53,7 +53,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	return rt.TableValue(pkg), nil
 }
 
-func abs(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func abs(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func abs(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func acos(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func acos(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func acos(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func asin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func asin(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func asin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func atan(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func atan(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func atan(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, z), nil
 }
 
-func ceil(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ceil(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func ceil(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func cos(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func cos(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func cos(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func deg(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func deg(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func deg(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func exp(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func exp(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func exp(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func floor(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func floor(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func floor(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func fmod(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func fmod(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func fmod(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, res), nil
 }
 
-func log(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func log(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func log(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.FloatValue(y)), nil
 }
 
-func max(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func max(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func max(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, x), nil
 }
 
-func min(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func min(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func min(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, x), nil
 }
 
-func modf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func modf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func modf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func rad(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rad(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -307,9 +307,9 @@ func rad(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 }
 
 // TODO: have a per runtime random generator
-func random(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func random(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
-		err *rt.Error
+		err error
 		m   int64 = 1
 		n   int64
 	)
@@ -351,9 +351,11 @@ func random(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.IntValue(m+r)), nil
 }
 
-func randomseed(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	var seed int64
-	var err *rt.Error
+func randomseed(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	var (
+		seed int64
+		err  error
+	)
 	switch c.NArgs() {
 	case 0:
 		// We need something as random as possible to make a seed.
@@ -382,7 +384,7 @@ func randomseed(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext(t.Runtime, rt.IntValue(seed), rt.IntValue(0)), nil
 }
 
-func sin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func sin(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -394,7 +396,7 @@ func sin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func sqrt(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func sqrt(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -406,7 +408,7 @@ func sqrt(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func tan(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tan(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -418,7 +420,7 @@ func tan(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, y), nil
 }
 
-func tointeger(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tointeger(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -429,7 +431,7 @@ func tointeger(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.IntValue(n)), nil
 }
 
-func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -443,7 +445,7 @@ func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, tp), nil
 }
 
-func ult(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func ult(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/mathlib/mathlib.go
+++ b/lib/mathlib/mathlib.go
@@ -3,6 +3,7 @@ package mathlib
 import (
 	crypto "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"math"
 	"math/rand"
 
@@ -68,7 +69,7 @@ func abs(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	case rt.IsFloat:
 		t.Push1(next, rt.FloatValue(math.Abs(f)))
 	default:
-		return nil, rt.NewErrorS("#1 must be a number")
+		return nil, errors.New("#1 must be a number")
 	}
 	return next, nil
 }
@@ -134,7 +135,7 @@ func ceil(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			t.Push1(next, rt.FloatValue(f))
 		}
 	default:
-		return nil, rt.NewErrorS("#1 must be a number")
+		return nil, errors.New("#1 must be a number")
 	}
 	return next, nil
 }
@@ -193,7 +194,7 @@ func floor(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			t.Push1(next, rt.FloatValue(f))
 		}
 	default:
-		return nil, rt.NewErrorS("#1 must be a number")
+		return nil, errors.New("#1 must be a number")
 	}
 	return next, nil
 }
@@ -206,7 +207,7 @@ func fmod(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	y, _ := rt.ToNumberValue(c.Arg(1))
 	res, ok, err := rt.Mod(x, y)
 	if !ok {
-		err = rt.NewErrorS("expected numeric arguments")
+		err = errors.New("expected numeric arguments")
 	}
 	if err != nil {
 		return nil, err
@@ -281,7 +282,7 @@ func modf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 
 	x, ok := arg.TryFloat()
 	if !ok {
-		return nil, rt.NewErrorS("#1 must be numeric")
+		return nil, errors.New("#1 must be numeric")
 	}
 	var i, f float64
 	if math.IsInf(x, 0) {
@@ -332,7 +333,7 @@ func random(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		return nil, err
 	}
 	if m > n {
-		return nil, rt.NewErrorS("#2 must be >= #1")
+		return nil, errors.New("#2 must be >= #1")
 	}
 	var r int64
 	if m <= 0 && m+math.MaxInt64 < n {
@@ -361,7 +362,7 @@ func randomseed(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		// We need something as random as possible to make a seed.
 		readErr := binary.Read(crypto.Reader, binary.LittleEndian, &seed)
 		if readErr != nil {
-			return nil, rt.NewErrorS("unable to get random seed")
+			return nil, errors.New("unable to get random seed")
 		}
 	case 1:
 		seed, err = c.IntArg(0)

--- a/lib/oslib/clock.go
+++ b/lib/oslib/clock.go
@@ -9,7 +9,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func clock(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func clock(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var rusage syscall.Rusage
 	_ = syscall.Getrusage(syscall.RUSAGE_SELF, &rusage) // ignore errors
 	time := float64(rusage.Utime.Sec+rusage.Stime.Sec) + float64(rusage.Utime.Usec+rusage.Stime.Usec)/1000000.0

--- a/lib/oslib/clock_windows.go
+++ b/lib/oslib/clock_windows.go
@@ -11,7 +11,7 @@ import (
 
 var startTime time.Time
 
-func clock(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func clock(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	// No syscall.Getrusage on windows.  As a fallback return clock time since
 	// starting the program.
 	time := float64(time.Now().Sub(startTime).Microseconds()) / 1e6

--- a/lib/oslib/oslib.go
+++ b/lib/oslib/oslib.go
@@ -85,7 +85,7 @@ func date(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		{
 			dateStr, fmtErr := strftime.StrictFormat(format, now)
 			if fmtErr != nil {
-				return nil, rt.NewErrorE(fmtErr)
+				return nil, fmtErr
 			}
 			date = rt.StringValue(dateStr)
 		}

--- a/lib/oslib/oslib.go
+++ b/lib/oslib/oslib.go
@@ -1,6 +1,7 @@
 package oslib
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -150,14 +151,14 @@ func timef(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		}
 		if val == rt.NilValue {
 			if required {
-				fieldErr = rt.NewErrorF("required field '%s' missing", name)
+				fieldErr = fmt.Errorf("required field '%s' missing", name)
 				return false
 			}
 			return true
 		}
 		iVal, ok := val.TryInt()
 		if !ok {
-			fieldErr = rt.NewErrorF("field '%s' is not an integer", name)
+			fieldErr = fmt.Errorf("field '%s' is not an integer", name)
 			return false
 		}
 		*dest = int(iVal)

--- a/lib/oslib/oslib.go
+++ b/lib/oslib/oslib.go
@@ -38,9 +38,9 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	return rt.TableValue(pkg), nil
 }
 
-func date(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func date(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
-		err    *rt.Error
+		err    error
 		utc    bool
 		now    time.Time
 		format string
@@ -93,7 +93,7 @@ func date(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, date), nil
 }
 
-func difftime(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func difftime(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func difftime(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.IntValue(t2-t1)), nil
 }
 
-func exit(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func exit(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		code  = 0 // 0 for success, 1 for failure
 		close = false
@@ -129,7 +129,7 @@ func exit(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return nil, nil
 }
 
-func timef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func timef(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if c.NArgs() == 0 {
 		now := time.Now().Unix()
 		return c.PushingNext1(t.Runtime, rt.IntValue(now)), nil
@@ -138,7 +138,7 @@ func timef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	if err != nil {
 		return nil, err
 	}
-	var fieldErr *rt.Error
+	var fieldErr error
 	var getField = func(dest *int, name string, required bool) bool {
 		if fieldErr != nil {
 			return false
@@ -183,7 +183,7 @@ func timef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.IntValue(date.Unix())), nil
 }
 
-func setlocale(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func setlocale(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func setlocale(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(locale)), nil
 }
 
-func getenv(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func getenv(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func getenv(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, valV), nil
 }
 
-func tmpname(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func tmpname(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	f, ioErr := safeio.TempFile(t.Runtime, "", "")
 	if ioErr != nil {
 		return t.ProcessIoError(c.Next(), ioErr)
@@ -226,7 +226,7 @@ func tmpname(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(name)), nil
 }
 
-func remove(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func remove(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func remove(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.BoolValue(true)), nil
 }
 
-func rename(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rename(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/packagelib/packagelib.go
+++ b/lib/packagelib/packagelib.go
@@ -130,7 +130,7 @@ func require(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	// First check is the module is already loaded
 	loaded, ok := pkg.Get(loadedKey).TryTable()
 	if !ok {
-		return nil, rt.NewErrorS("package.loaded must be a table")
+		return nil, errors.New("package.loaded must be a table")
 	}
 	next := c.Next()
 	if mod := loaded.Get(nameVal); !mod.IsNil() {
@@ -141,13 +141,13 @@ func require(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	// If not, then go through the searchers
 	searchers, ok := pkg.Get(searchersKey).TryTable()
 	if !ok {
-		return nil, rt.NewErrorS("package.searchers must be a table")
+		return nil, errors.New("package.searchers must be a table")
 	}
 
 	for i := int64(1); ; i++ {
 		searcher := searchers.Get(rt.IntValue(i))
 		if searcher.IsNil() {
-			err = rt.NewErrorF("could not find package '%s'", name)
+			err = fmt.Errorf("could not find package '%s'", name)
 			break
 		}
 		res := rt.NewTerminationWith(c, 2, false)
@@ -247,7 +247,7 @@ func searchLua(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	pkg := pkgTable(t.Runtime)
 	path, ok := pkg.Get(pathKey).TryString()
 	if !ok {
-		return nil, rt.NewErrorS("package.path must be a string")
+		return nil, errors.New("package.path must be a string")
 	}
 	conf := getConfig(pkg)
 	found, templates := searchPath(string(s), string(path), ".", conf)
@@ -278,11 +278,11 @@ func loadLua(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	src, readErr := ioutil.ReadFile(string(filePath))
 	if readErr != nil {
-		return nil, rt.NewErrorF("error reading file: %s", readErr)
+		return nil, fmt.Errorf("error reading file: %s", readErr)
 	}
 	clos, compErr := t.LoadFromSourceOrCode(string(filePath), src, "bt", rt.TableValue(t.GlobalEnv()), true)
 	if compErr != nil {
-		return nil, rt.NewErrorF("error compiling file: %s", compErr)
+		return nil, fmt.Errorf("error compiling file: %s", compErr)
 	}
 	return rt.Continue(t, rt.FunctionValue(clos), c.Next())
 }

--- a/lib/packagelib/packagelib.go
+++ b/lib/packagelib/packagelib.go
@@ -116,7 +116,7 @@ func getConfig(pkg *rt.Table) *config {
 	return conf
 }
 
-func require(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func require(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func require(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return nil, err
 }
 
-func searchpath(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func searchpath(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		name, path string
 		sep        = "."
@@ -224,7 +224,7 @@ func searchPath(name, path, dot string, conf *config) (string, []string) {
 	return "", templates
 }
 
-func searchPreload(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func searchPreload(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func searchPreload(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, loader), nil
 }
 
-func searchLua(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func searchLua(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ var (
 	searchPreloadGoFunc = rt.NewGoFunction(searchPreload, "searchpreload", 1, false)
 )
 
-func loadLua(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func loadLua(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/runtimelib/ctx.go
+++ b/lib/runtimelib/ctx.go
@@ -79,7 +79,7 @@ func valueToResources(v rt.Value) (res rt.RuntimeResources, ok bool) {
 	return
 }
 
-func contextArg(c *rt.GoCont, n int) (rt.RuntimeContext, *rt.Error) {
+func contextArg(c *rt.GoCont, n int) (rt.RuntimeContext, error) {
 	ctx, ok := valueToContext(c.Arg(n))
 	if ok {
 		return ctx, nil
@@ -87,14 +87,14 @@ func contextArg(c *rt.GoCont, n int) (rt.RuntimeContext, *rt.Error) {
 	return nil, rt.NewErrorF("#%d must be a runtime context", n+1)
 }
 
-func optContextArg(t *rt.Thread, c *rt.GoCont, n int) (rt.RuntimeContext, *rt.Error) {
+func optContextArg(t *rt.Thread, c *rt.GoCont, n int) (rt.RuntimeContext, error) {
 	if n >= c.NArgs() {
 		return t.RuntimeContext(), nil
 	}
 	return contextArg(c, n)
 }
 
-func resourcesArg(c *rt.GoCont, n int) (rt.RuntimeResources, *rt.Error) {
+func resourcesArg(c *rt.GoCont, n int) (rt.RuntimeResources, error) {
 	res, ok := valueToResources(c.Arg(n))
 	if ok {
 		return res, nil
@@ -102,7 +102,7 @@ func resourcesArg(c *rt.GoCont, n int) (rt.RuntimeResources, *rt.Error) {
 	return res, rt.NewErrorF("#%d must be a runtime resources", n+1)
 }
 
-func context__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func context__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	ctx, err := contextArg(c, 0)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func context__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, val), nil
 }
 
-func context__tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func context__tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	ctx, err := contextArg(c, 0)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func context__tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, statusValue(ctx.Status())), nil
 }
 
-func resources__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func resources__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	res, err := resourcesArg(c, 0)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func resources__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, val), nil
 }
 
-func resources__tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func resources__tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	res, err := resourcesArg(c, 0)
 	if err != nil {
 		return nil, err
@@ -212,7 +212,7 @@ func statusValue(st rt.RuntimeContextStatus) rt.Value {
 	return rt.StringValue(s)
 }
 
-func killnow(t *rt.Thread, c *rt.GoCont) (next rt.Cont, err *rt.Error) {
+func killnow(t *rt.Thread, c *rt.GoCont) (next rt.Cont, err error) {
 	ctx, err := optContextArg(t, c, 0)
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func killnow(t *rt.Thread, c *rt.GoCont) (next rt.Cont, err *rt.Error) {
 	return nil, nil
 }
 
-func stopnow(t *rt.Thread, c *rt.GoCont) (next rt.Cont, err *rt.Error) {
+func stopnow(t *rt.Thread, c *rt.GoCont) (next rt.Cont, err error) {
 	ctx, err := optContextArg(t, c, 0)
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func stopnow(t *rt.Thread, c *rt.GoCont) (next rt.Cont, err *rt.Error) {
 	return c.Next(), nil
 }
 
-func due(t *rt.Thread, c *rt.GoCont) (next rt.Cont, retErr *rt.Error) {
+func due(t *rt.Thread, c *rt.GoCont) (next rt.Cont, retErr error) {
 	ctx, err := optContextArg(t, c, 0)
 	if err != nil {
 		return nil, err

--- a/lib/runtimelib/ctx.go
+++ b/lib/runtimelib/ctx.go
@@ -84,7 +84,7 @@ func contextArg(c *rt.GoCont, n int) (rt.RuntimeContext, error) {
 	if ok {
 		return ctx, nil
 	}
-	return nil, rt.NewErrorF("#%d must be a runtime context", n+1)
+	return nil, fmt.Errorf("#%d must be a runtime context", n+1)
 }
 
 func optContextArg(t *rt.Thread, c *rt.GoCont, n int) (rt.RuntimeContext, error) {
@@ -99,7 +99,7 @@ func resourcesArg(c *rt.GoCont, n int) (rt.RuntimeResources, error) {
 	if ok {
 		return res, nil
 	}
-	return res, rt.NewErrorF("#%d must be a runtime resources", n+1)
+	return res, fmt.Errorf("#%d must be a runtime resources", n+1)
 }
 
 func context__index(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {

--- a/lib/runtimelib/runtimelib.go
+++ b/lib/runtimelib/runtimelib.go
@@ -1,6 +1,8 @@
 package runtimelib
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/arnodel/golua/lib/packagelib"
@@ -70,12 +72,12 @@ func callcontext(t *rt.Thread, c *rt.GoCont) (next rt.Cont, retErr error) {
 	if !flagsV.IsNil() {
 		flagsStr, ok := flagsV.TryString()
 		if !ok {
-			return nil, rt.NewErrorS("flags must be a string")
+			return nil, errors.New("flags must be a string")
 		}
 		for _, name := range strings.Fields(flagsStr) {
 			flags, ok = flags.AddFlagWithName(name)
 			if !ok {
-				return nil, rt.NewErrorF("unknown flag: %q", name)
+				return nil, fmt.Errorf("unknown flag: %q", name)
 			}
 		}
 	}
@@ -131,11 +133,11 @@ func validateResVal(key rt.Value, val rt.Value) (uint64, error) {
 	n, ok := rt.ToIntNoString(val)
 	if !ok {
 		name, _ := key.ToString()
-		return 0, rt.NewErrorF("%s must be an integer", name)
+		return 0, fmt.Errorf("%s must be an integer", name)
 	}
 	if n <= 0 {
 		name, _ := key.ToString()
-		return 0, rt.NewErrorF("%s must be a positive integer", name)
+		return 0, fmt.Errorf("%s must be a positive integer", name)
 	}
 	return uint64(n), nil
 }
@@ -161,10 +163,10 @@ func validateTimeVal(val rt.Value, factor float64, name string) (uint64, error) 
 	}
 	s, ok := rt.ToFloat(val)
 	if !ok {
-		return 0, rt.NewErrorF("%s must be a numeric value", name)
+		return 0, fmt.Errorf("%s must be a numeric value", name)
 	}
 	if s <= 0 {
-		return 0, rt.NewErrorF("%s must be positive", name)
+		return 0, fmt.Errorf("%s must be positive", name)
 	}
 	return uint64(s * factor), nil
 }

--- a/lib/stringlib/dump.go
+++ b/lib/stringlib/dump.go
@@ -27,7 +27,7 @@ func dump(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	// worry about the rest of this codepath in this case.
 	t.LinearRequire(10, used)
 	if err != nil {
-		return nil, rt.NewErrorE(mErr)
+		return nil, mErr
 	}
 	return c.PushingNext1(t.Runtime, rt.StringValue(w.String())), nil
 }

--- a/lib/stringlib/dump.go
+++ b/lib/stringlib/dump.go
@@ -6,7 +6,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func dump(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func dump(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/stringlib/format.go
+++ b/lib/stringlib/format.go
@@ -1,6 +1,7 @@
 package stringlib
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -26,7 +27,7 @@ func format(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(s)), nil
 }
 
-var errNotEnoughValues = rt.NewErrorS("not enough values for format string")
+var errNotEnoughValues = errors.New("not enough values for format string")
 
 // Format is the base for the implementation of lua string.format()
 //
@@ -70,7 +71,7 @@ OuterLoop:
 					}
 					n, ok := rt.ToInt(values[j])
 					if !ok {
-						return "", rt.NewErrorS("invalid value for integer format")
+						return "", errors.New("invalid value for integer format")
 					}
 					arg = []byte{byte(n)}
 					tmpMem += t.RequireBytes(1)
@@ -83,7 +84,7 @@ OuterLoop:
 					}
 					n, ok := rt.ToInt(values[j])
 					if !ok {
-						return "", rt.NewErrorS("invalid value for integer format")
+						return "", errors.New("invalid value for integer format")
 					}
 					tmpMem += t.RequireBytes(10)
 					switch format[i] {
@@ -112,7 +113,7 @@ OuterLoop:
 					}
 					f, ok := rt.ToFloat(values[j])
 					if !ok {
-						return "", rt.NewErrorS("invalid value for float format")
+						return "", errors.New("invalid value for float format")
 					}
 					tmpMem += t.RequireBytes(10)
 					arg = float64(f)
@@ -131,7 +132,7 @@ OuterLoop:
 				case 'q':
 					// quote, only for literals I think
 					if start < i {
-						return "", rt.NewErrorS("specifier '%q' cannot have modifiers")
+						return "", errors.New("specifier '%q' cannot have modifiers")
 					}
 					if len(args) <= j {
 						return "", errNotEnoughValues
@@ -142,7 +143,7 @@ OuterLoop:
 						arg = s
 						outFormat[i] = 's'
 					} else {
-						return "", rt.NewErrorS("no literal")
+						return "", errors.New("no literal")
 					}
 					break ArgLoop
 				case 'p':
@@ -172,7 +173,7 @@ OuterLoop:
 					}
 					b, ok := values[j].TryBool()
 					if !ok {
-						return "", rt.NewErrorS("invalid value for boolean format")
+						return "", errors.New("invalid value for boolean format")
 					}
 					tmpMem += t.RequireBytes(5)
 					arg = bool(b)
@@ -183,19 +184,19 @@ OuterLoop:
 					if foundDot {
 						prec = prec*10 + int(format[i]-'0')
 						if prec >= 100 {
-							return "", rt.NewErrorS("length too long")
+							return "", errors.New("length too long")
 						}
 					} else {
 						length = length*10 + int(format[i]-'0')
 						if length >= 100 {
-							return "", rt.NewErrorS("precision too long")
+							return "", errors.New("precision too long")
 						}
 					}
 				case '+', '-', '#', ' ':
 					// flag characters
 				default:
 					// Unrecognised verbs
-					return "", rt.NewErrorS("invalid format string")
+					return "", errors.New("invalid format string")
 				}
 			}
 			args[j] = arg

--- a/lib/stringlib/format.go
+++ b/lib/stringlib/format.go
@@ -10,7 +10,7 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func format(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func format(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ var errNotEnoughValues = rt.NewErrorS("not enough values for format string")
 // It temporarily requires all the memory needed to store the formatted string,
 // but releases it before returning so the caller should require memory first
 // thing after the call.
-func Format(t *rt.Thread, format string, values []rt.Value) (string, *rt.Error) {
+func Format(t *rt.Thread, format string, values []rt.Value) (string, error) {
 	var tmpMem uint64
 	defer t.ReleaseMem(tmpMem)
 	// Temporarily require memory for building the argument list

--- a/lib/stringlib/matching.go
+++ b/lib/stringlib/matching.go
@@ -1,6 +1,8 @@
 package stringlib
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -303,7 +305,7 @@ func gsub(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			return subToString(t.Runtime, s[gc.Start():gc.End()], term.Get(0))
 		}
 	} else {
-		return nil, rt.NewErrorS("#3 must be a string, table or function")
+		return nil, errors.New("#3 must be a string, table or function")
 	}
 	var (
 		si         int             // Index in s where to start finding the next match
@@ -376,5 +378,5 @@ func subToString(r *rt.Runtime, key string, val rt.Value) (string, bool, error) 
 		r.RequireBytes(len(res))
 		return res, false, nil
 	}
-	return "", false, rt.NewErrorF("invalid replacement value (a %s)", val.TypeName())
+	return "", false, fmt.Errorf("invalid replacement value (a %s)", val.TypeName())
 }

--- a/lib/stringlib/matching.go
+++ b/lib/stringlib/matching.go
@@ -53,7 +53,7 @@ func find(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	default:
 		pat, err := pattern.New(string(ptn))
 		if err != nil {
-			return nil, rt.NewErrorE(err)
+			return nil, err
 		}
 		captures, usedCPU := pat.MatchFromStart(string(s), si, t.UnusedCPU())
 		t.RequireCPU(usedCPU)
@@ -94,7 +94,7 @@ func match(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	next := c.Next()
 	pat, ptnErr := pattern.New(string(ptn))
 	if ptnErr != nil {
-		return nil, rt.NewErrorE(ptnErr)
+		return nil, ptnErr
 	}
 	captures, usedCPU := pat.MatchFromStart(string(s), si, t.UnusedCPU())
 	t.RequireCPU(usedCPU)
@@ -152,7 +152,7 @@ func gmatch(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	pat, ptnErr := pattern.New(string(ptn))
 	if ptnErr != nil {
-		return nil, rt.NewErrorE(ptnErr)
+		return nil, ptnErr
 	}
 	si := luastrings.StringNormPos(s, int(init)) - 1
 	if si < 0 {
@@ -215,7 +215,7 @@ func gsub(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	repl = c.Arg(2)
 	pat, ptnErr := pattern.New(string(ptn))
 	if ptnErr != nil {
-		return nil, rt.NewErrorE(ptnErr)
+		return nil, ptnErr
 	}
 
 	// replF will be the function that does the substitution of the match given
@@ -254,7 +254,7 @@ func gsub(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 				case '0' <= b && b <= '9':
 					idx := int(b - '0')
 					if idx > maxIndex {
-						err = rt.NewErrorE(pattern.ErrInvalidCaptureIdx(idx))
+						err = pattern.ErrInvalidCaptureIdx(idx)
 						return ""
 					}
 					s := cStrings[b-'0']
@@ -265,7 +265,7 @@ func gsub(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 				case b == '%':
 					return x[1:]
 				default:
-					err = rt.NewErrorE(pattern.ErrInvalidPct)
+					err = pattern.ErrInvalidPct
 				}
 				return x[1:]
 			}), false, err

--- a/lib/stringlib/packing.go
+++ b/lib/stringlib/packing.go
@@ -82,7 +82,7 @@ Xop: an empty item that aligns according to option op (which is otherwise ignore
 ' ': (empty space) ignored
 */
 
-func pack(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func pack(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -98,14 +98,14 @@ func pack(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(res)), nil
 }
 
-func unpack(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func unpack(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
 	var (
 		format, pack string
 		n            int64 = 1
-		err          *rt.Error
+		err          error
 	)
 	format, err = c.StringArg(0)
 	if err == nil {
@@ -132,7 +132,7 @@ func unpack(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func packsize(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func packsize(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}

--- a/lib/stringlib/packing.go
+++ b/lib/stringlib/packing.go
@@ -93,7 +93,7 @@ func pack(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	res, used, perr := PackValues(string(format), c.Etc(), t.LinearUnused(10))
 	t.LinearRequire(10, used)
 	if perr != nil {
-		return nil, rt.NewErrorE(perr)
+		return nil, perr
 	}
 	return c.PushingNext1(t.Runtime, rt.StringValue(res)), nil
 }
@@ -124,7 +124,7 @@ func unpack(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	vals, m, used, uerr := UnpackString(string(format), string(pack), i, t.LinearUnused(10))
 	t.LinearRequire(10, used)
 	if uerr != nil {
-		return nil, rt.NewErrorE(uerr)
+		return nil, uerr
 	}
 	next := c.Next()
 	t.Push(next, vals...)
@@ -142,7 +142,7 @@ func packsize(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	size, serr := PackSize(string(format))
 	if serr != nil {
-		return nil, rt.NewErrorE(serr)
+		return nil, serr
 	}
 	return c.PushingNext1(t.Runtime, rt.IntValue(int64(size))), nil
 }

--- a/lib/stringlib/packing.go
+++ b/lib/stringlib/packing.go
@@ -116,7 +116,7 @@ func unpack(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	i := luastrings.StringNormPos(pack, int(n)) - 1
 	if i < 0 || i > len(pack) {
-		err = rt.NewErrorS("#3 out of string")
+		err = errors.New("#3 out of string")
 	}
 	if err != nil {
 		return nil, err

--- a/lib/stringlib/string_arith.go
+++ b/lib/stringlib/string_arith.go
@@ -13,8 +13,8 @@ var (
 	string__unm  = stringUnOp(rt.Unm, "__unm")
 )
 
-func stringBinOp(f func(x, y rt.Value) (rt.Value, bool), op string) func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	return func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func stringBinOp(f func(x, y rt.Value) (rt.Value, bool), op string) func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	return func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		if err := c.CheckNArgs(2); err != nil {
 			return nil, err
 		}
@@ -39,8 +39,8 @@ func stringBinOp(f func(x, y rt.Value) (rt.Value, bool), op string) func(t *rt.T
 	}
 }
 
-func stringBinOpErr(f func(x, y rt.Value) (rt.Value, bool, *rt.Error), op string) func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	return func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func stringBinOpErr(f func(x, y rt.Value) (rt.Value, bool, error), op string) func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	return func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		if err := c.CheckNArgs(2); err != nil {
 			return nil, err
 		}
@@ -68,8 +68,8 @@ func stringBinOpErr(f func(x, y rt.Value) (rt.Value, bool, *rt.Error), op string
 	}
 }
 
-func stringUnOp(f func(x rt.Value) (rt.Value, bool), op string) func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	return func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func stringUnOp(f func(x rt.Value) (rt.Value, bool), op string) func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
+	return func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		if err := c.Check1Arg(); err != nil {
 			return nil, err
 		}

--- a/lib/stringlib/stringlib.go
+++ b/lib/stringlib/stringlib.go
@@ -74,7 +74,7 @@ func minpos(i, j int) int {
 	return j
 }
 
-func bytef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func bytef(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func bytef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	vals := c.Etc()
 	buf := make([]byte, len(vals))
 	for i, v := range vals {
@@ -125,7 +125,7 @@ func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(string(buf))), nil
 }
 
-func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.IntValue(int64(len(s)))), nil
 }
 
-func lower(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func lower(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func lower(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(s)), nil
 }
 
-func upper(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func upper(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func upper(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(s)), nil
 }
 
-func rep(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func rep(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func rep(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(builder.String())), nil
 }
 
-func reverse(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func reverse(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func reverse(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(string(sb))), nil
 }
 
-func sub(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func sub(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/stringlib/stringlib.go
+++ b/lib/stringlib/stringlib.go
@@ -1,6 +1,8 @@
 package stringlib
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/arnodel/golua/lib/packagelib"
@@ -114,10 +116,10 @@ func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	for i, v := range vals {
 		x, ok := rt.ToInt(v)
 		if !ok {
-			return nil, rt.NewErrorS("arguments must be integers")
+			return nil, errors.New("arguments must be integers")
 		}
 		if x < 0 || x > 255 {
-			return nil, rt.NewErrorF("#%d out of range", i+1)
+			return nil, fmt.Errorf("#%d out of range", i+1)
 		}
 		buf[i] = byte(x)
 	}
@@ -176,7 +178,7 @@ func rep(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	}
 	n := int(ln)
 	if n < 0 {
-		return nil, rt.NewErrorS("#2 out of range")
+		return nil, errors.New("#2 out of range")
 	}
 	var sep []byte
 	if c.NArgs() >= 3 {
@@ -195,7 +197,7 @@ func rep(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if sep == nil {
 		if len(ls)*n/n != len(ls) {
 			// Overflow
-			return nil, rt.NewErrorS("rep causes overflow")
+			return nil, errors.New("rep causes overflow")
 		}
 		t.RequireBytes(n * len(ls))
 		return c.PushingNext1(t.Runtime, rt.StringValue(strings.Repeat(string(ls), n))), nil
@@ -206,7 +208,7 @@ func rep(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	sz2 := (n - 1) * len(sep)
 	sz := sz1 + sz2
 	if sz1/n != len(s) || sz2/(n-1) != len(sep) || sz < 0 {
-		return nil, rt.NewErrorS("rep causes overflow")
+		return nil, errors.New("rep causes overflow")
 	}
 	t.RequireBytes(n*len(s) + (n-1)*len(sep))
 	builder.Grow(sz)

--- a/lib/tablelib/tablelib.go
+++ b/lib/tablelib/tablelib.go
@@ -374,7 +374,7 @@ func sortf(t *rt.Thread, c *rt.GoCont) (next rt.Cont, resErr error) {
 	}
 	l, err := rt.IntLen(t, tblVal)
 	if err != nil {
-		return nil, rt.NewErrorE(err)
+		return nil, err
 	}
 	if l >= maxSortSize {
 		return nil, rt.NewErrorS("too big to sort")

--- a/lib/tablelib/tablelib.go
+++ b/lib/tablelib/tablelib.go
@@ -1,6 +1,8 @@
 package tablelib
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -115,7 +117,7 @@ func concat(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 
 func errInvalidConcatValue(v rt.Value, i int64) error {
 	s, _ := v.ToString()
-	return rt.NewErrorF("invalid value (%s) at index %d in table for 'concat'", s, i)
+	return fmt.Errorf("invalid value (%s) at index %d in table for 'concat'", s, i)
 }
 
 func insert(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
@@ -141,7 +143,7 @@ func insert(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			return nil, err
 		}
 		if pos <= 0 || pos > tblLen+1 {
-			return nil, rt.NewErrorS("#2 out of range")
+			return nil, errors.New("#2 out of range")
 		}
 		val = c.Arg(2)
 	} else {
@@ -205,14 +207,14 @@ func move(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if srcStart > srcEnd || srcStart == dstStart && dstVal == srcVal {
 		// Nothing to do apparently!
 	} else if srcStart <= 0 && srcStart+math.MaxInt64 <= srcEnd {
-		return nil, rt.NewErrorS("interval too large")
+		return nil, errors.New("interval too large")
 	} else if dstStart >= srcStart {
 		// Move in descending order to avoid writing at a position
 		// before moving it
 		offset := srcEnd - srcStart // 0 <= offset < math.MaxInt64
 		if dstStart > math.MaxInt64-offset {
 			// Not enough space to move
-			return nil, rt.NewErrorS("destination would wrap around")
+			return nil, errors.New("destination would wrap around")
 		}
 		dstStart += offset
 		for srcEnd >= srcStart {
@@ -297,7 +299,7 @@ func remove(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			return nil, err
 		}
 	case pos <= 0 || pos > tblLen:
-		return nil, rt.NewErrorS("#2 out of range")
+		return nil, errors.New("#2 out of range")
 	default:
 		var newVal rt.Value
 		for pos <= tblLen {
@@ -377,7 +379,7 @@ func sortf(t *rt.Thread, c *rt.GoCont) (next rt.Cont, resErr error) {
 		return nil, err
 	}
 	if l >= maxSortSize {
-		return nil, rt.NewErrorS("too big to sort")
+		return nil, errors.New("too big to sort")
 	}
 	if l <= 0 {
 		return c.Next(), nil
@@ -456,7 +458,7 @@ func unpack(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		return nil, err
 	}
 	if i < math.MaxInt64-maxUnpackSize && i+maxUnpackSize <= j {
-		return nil, rt.NewErrorS("too many values to unpack")
+		return nil, errors.New("too many values to unpack")
 	}
 	next := c.Next()
 	for ; i <= j; i++ {

--- a/lib/utf8lib/utf8lib.go
+++ b/lib/utf8lib/utf8lib.go
@@ -33,7 +33,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	return rt.TableValue(pkg), nil
 }
 
-func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	runes := c.Etc()
 	maxLen := len(runes) * luastrings.UTFMax
 	t.RequireBytes(maxLen)
@@ -57,11 +57,11 @@ func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.StringValue(string(buf[:bufLen]))), nil
 }
 
-func codes(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func codes(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	var (
 		s   string
 		lax bool
-		err *rt.Error
+		err error
 	)
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func codes(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	}
 	decode := luastrings.GetDecodeRuneInString(lax)
 	var p int64
-	var iterF = func(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+	var iterF = func(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		t.RequireCPU(1)
 		next := c.Next()
 		r, n := decode(s[p:])
@@ -101,7 +101,7 @@ func codes(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return c.PushingNext1(t.Runtime, rt.FunctionValue(iter)), nil
 }
 
-func codepoint(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func codepoint(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func codepoint(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.Check1Arg(); err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	return next, nil
 }
 
-func offset(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+func offset(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	if err := c.CheckNArgs(2); err != nil {
 		return nil, err
 	}

--- a/lib/utf8lib/utf8lib.go
+++ b/lib/utf8lib/utf8lib.go
@@ -87,7 +87,7 @@ func codes(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 			case 0:
 				return next, nil
 			case 1:
-				return nil, rt.NewErrorE(errInvalidCode)
+				return nil, errInvalidCode
 			}
 			// If n > 1, then it is a successful decode in lax mode.
 		}
@@ -125,17 +125,17 @@ func codepoint(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	next := c.Next()
 	i := luastrings.StringNormPos(s, int(ii))
 	if i < 1 {
-		return nil, rt.NewErrorE(errPosOutOfRange)
+		return nil, errPosOutOfRange
 	}
 	j := luastrings.StringNormPos(s, int(jj))
 	if j > len(s) {
-		return nil, rt.NewErrorE(errPosOutOfRange)
+		return nil, errPosOutOfRange
 	}
 	for k := i - 1; k < j; {
 		t.RequireCPU(1)
 		r, sz := decode(s[k:])
 		if r == utf8.RuneError && sz <= 1 {
-			return nil, rt.NewErrorE(errInvalidCode)
+			return nil, errInvalidCode
 		}
 		t.Push1(next, rt.IntValue(int64(r)))
 		k += sz
@@ -171,7 +171,7 @@ func lenf(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		slen   int64
 	)
 	if i <= 0 || i > len(s)+1 || j > len(s) {
-		return nil, rt.NewErrorE(errPosOutOfRange)
+		return nil, errPosOutOfRange
 	}
 	for k := i - 1; k < j; {
 		t.RequireCPU(1)
@@ -210,7 +210,7 @@ func offset(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	i := luastrings.StringNormPos(ss, int(ii)) - 1
 	s := string(ss)
 	if i < 0 || i > len(s) {
-		return nil, rt.NewErrorE(errPosOutOfRange)
+		return nil, errPosOutOfRange
 	}
 	if nn == 0 {
 		// Special case: locate the starting position of the current

--- a/lib/utf8lib/utf8lib.go
+++ b/lib/utf8lib/utf8lib.go
@@ -2,6 +2,7 @@ package utf8lib
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"unicode/utf8"
 
@@ -44,10 +45,10 @@ func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 	for i, r := range runes {
 		n, ok := rt.ToInt(r)
 		if !ok {
-			return nil, rt.NewErrorF("#%d should be an integer", i+1)
+			return nil, fmt.Errorf("#%d should be an integer", i+1)
 		}
 		if n < 0 || n > math.MaxInt32 {
-			return nil, rt.NewErrorF("#%d value out of range", i+1)
+			return nil, fmt.Errorf("#%d value out of range", i+1)
 		}
 		sz := luastrings.UTF8EncodeInt32(cur, int32(n))
 		cur = cur[sz:]
@@ -221,7 +222,7 @@ func offset(t *rt.Thread, c *rt.GoCont) (rt.Cont, error) {
 		}
 	} else {
 		if i < len(s) && !utf8.RuneStart(s[i]) {
-			return nil, rt.NewErrorS("initial position is a continuation byte")
+			return nil, errors.New("initial position is a continuation byte")
 		}
 		if nn > 0 {
 			nn--

--- a/runtime/arith.go
+++ b/runtime/arith.go
@@ -121,7 +121,7 @@ func floordivFloat(x, y float64) float64 {
 // Div returns (z, true, nil) where z is the (integer) value representing x//y
 // if x and y are numbers and y != 0, if y == 0 it returns (NilValue, true,
 // div_by_zero_error), else (NilValue, false, nil) if x or y is not a number.
-func Idiv(x Value, y Value) (Value, bool, *Error) {
+func Idiv(x Value, y Value) (Value, bool, error) {
 	switch x.iface.(type) {
 	case int64:
 		switch y.iface.(type) {
@@ -165,7 +165,7 @@ func modFloat(x, y float64) float64 {
 // representing x%y if x and y are numbers and y != 0, if y == 0 it returns
 // (NilValue, true, mod_by_zero_error), else (NilValue, false, nil) if x or y is
 // not a number.
-func Mod(x Value, y Value) (Value, bool, *Error) {
+func Mod(x Value, y Value) (Value, bool, error) {
 	switch x.iface.(type) {
 	case int64:
 		switch y.iface.(type) {
@@ -216,7 +216,7 @@ func Pow(x, y Value) (Value, bool) {
 	return FloatValue(powFloat(fx, fy)), true
 }
 
-func binaryArithFallback(t *Thread, op string, x, y Value) (Value, *Error) {
+func binaryArithFallback(t *Thread, op string, x, y Value) (Value, error) {
 	res, err, ok := metabin(t, op, x, y)
 	if ok {
 		return res, err
@@ -226,7 +226,7 @@ func binaryArithFallback(t *Thread, op string, x, y Value) (Value, *Error) {
 
 // BinaryArithmeticError returns an error describing the problem with trying to
 // perform x op y.
-func BinaryArithmeticError(op string, x, y Value) *Error {
+func BinaryArithmeticError(op string, x, y Value) error {
 	var wrongVal Value
 	switch {
 	case numberType(y) != NaN:
@@ -239,7 +239,7 @@ func BinaryArithmeticError(op string, x, y Value) *Error {
 	return NewErrorF("attempt to perform arithmetic on a %s value", wrongVal.CustomTypeName())
 }
 
-func unaryArithFallback(t *Thread, op string, x Value) (Value, *Error) {
+func unaryArithFallback(t *Thread, op string, x Value) (Value, error) {
 	res, err, ok := metaun(t, op, x)
 	if ok {
 		return res, err
@@ -249,6 +249,6 @@ func unaryArithFallback(t *Thread, op string, x Value) (Value, *Error) {
 
 // UnaryArithmeticError returns an error describing the problem with trying to
 // perform the unary operation op(x).
-func UnaryArithmeticError(op string, x Value) *Error {
+func UnaryArithmeticError(op string, x Value) error {
 	return NewErrorF("attempt to %s a '%s'", op, x.CustomTypeName())
 }

--- a/runtime/arith.go
+++ b/runtime/arith.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"errors"
+	"fmt"
 	"math"
 )
 
@@ -128,7 +130,7 @@ func Idiv(x Value, y Value) (Value, bool, error) {
 		case int64:
 			ny := y.AsInt()
 			if ny == 0 {
-				return NilValue, true, NewErrorS("attempt to divide by zero")
+				return NilValue, true, errors.New("attempt to divide by zero")
 			}
 			return IntValue(floordivInt(x.AsInt(), ny)), true, nil
 		case float64:
@@ -172,7 +174,7 @@ func Mod(x Value, y Value) (Value, bool, error) {
 		case int64:
 			ny := y.AsInt()
 			if ny == 0 {
-				return NilValue, true, NewErrorS("attempt to perform 'n%0'")
+				return NilValue, true, errors.New("attempt to perform 'n%0'")
 			}
 			return IntValue(modInt(x.AsInt(), ny)), true, nil
 		case float64:
@@ -234,9 +236,9 @@ func BinaryArithmeticError(op string, x, y Value) error {
 	case numberType(x) != NaN:
 		wrongVal = y
 	default:
-		return NewErrorF("attempt to %s a '%s' with a '%s'", op, x.CustomTypeName(), y.CustomTypeName())
+		return fmt.Errorf("attempt to %s a '%s' with a '%s'", op, x.CustomTypeName(), y.CustomTypeName())
 	}
-	return NewErrorF("attempt to perform arithmetic on a %s value", wrongVal.CustomTypeName())
+	return fmt.Errorf("attempt to perform arithmetic on a %s value", wrongVal.CustomTypeName())
 }
 
 func unaryArithFallback(t *Thread, op string, x Value) (Value, error) {
@@ -250,5 +252,5 @@ func unaryArithFallback(t *Thread, op string, x Value) (Value, error) {
 // UnaryArithmeticError returns an error describing the problem with trying to
 // perform the unary operation op(x).
 func UnaryArithmeticError(op string, x Value) error {
-	return NewErrorF("attempt to %s a '%s'", op, x.CustomTypeName())
+	return fmt.Errorf("attempt to %s a '%s'", op, x.CustomTypeName())
 }

--- a/runtime/bitwise.go
+++ b/runtime/bitwise.go
@@ -1,5 +1,7 @@
 package runtime
 
+import "fmt"
+
 func band(t *Thread, x, y Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	iy, oky := ToIntNoString(y)
@@ -105,7 +107,7 @@ func binaryBitwiseError(op string, x, y Value, okx, oky bool) error {
 		wrongVal = x
 	}
 	if wrongVal.Type() == FloatType {
-		return NewErrorF("number has no integer representation")
+		return fmt.Errorf("number has no integer representation")
 	}
-	return NewErrorF("attempt to perform bitwise %s on a %s value", op, wrongVal.CustomTypeName())
+	return fmt.Errorf("attempt to perform bitwise %s on a %s value", op, wrongVal.CustomTypeName())
 }

--- a/runtime/bitwise.go
+++ b/runtime/bitwise.go
@@ -1,6 +1,6 @@
 package runtime
 
-func band(t *Thread, x, y Value) (Value, *Error) {
+func band(t *Thread, x, y Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	iy, oky := ToIntNoString(y)
 	if okx && oky {
@@ -13,7 +13,7 @@ func band(t *Thread, x, y Value) (Value, *Error) {
 	return NilValue, binaryBitwiseError("and", x, y, okx, oky)
 }
 
-func bor(t *Thread, x, y Value) (Value, *Error) {
+func bor(t *Thread, x, y Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	iy, oky := ToIntNoString(y)
 	if okx && oky {
@@ -26,7 +26,7 @@ func bor(t *Thread, x, y Value) (Value, *Error) {
 	return NilValue, binaryBitwiseError("or", x, y, okx, oky)
 }
 
-func bxor(t *Thread, x, y Value) (Value, *Error) {
+func bxor(t *Thread, x, y Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	iy, oky := ToIntNoString(y)
 	if okx && oky {
@@ -39,7 +39,7 @@ func bxor(t *Thread, x, y Value) (Value, *Error) {
 	return NilValue, binaryBitwiseError("xor", x, y, okx, oky)
 }
 
-func shl(t *Thread, x, y Value) (Value, *Error) {
+func shl(t *Thread, x, y Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	iy, oky := ToIntNoString(y)
 
@@ -58,7 +58,7 @@ func shl(t *Thread, x, y Value) (Value, *Error) {
 	return NilValue, binaryBitwiseError("shl", x, y, okx, oky)
 }
 
-func shr(t *Thread, x, y Value) (Value, *Error) {
+func shr(t *Thread, x, y Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	iy, oky := ToIntNoString(y)
 
@@ -77,7 +77,7 @@ func shr(t *Thread, x, y Value) (Value, *Error) {
 	return NilValue, binaryBitwiseError("shr", x, y, okx, oky)
 }
 
-func bnot(t *Thread, x Value) (Value, *Error) {
+func bnot(t *Thread, x Value) (Value, error) {
 	ix, okx := ToIntNoString(x)
 	if okx {
 		return IntValue(^ix), nil
@@ -89,7 +89,7 @@ func bnot(t *Thread, x Value) (Value, *Error) {
 	return NilValue, binaryBitwiseError("not", x, x, false, true)
 }
 
-func binaryBitwiseError(op string, x, y Value, okx, oky bool) *Error {
+func binaryBitwiseError(op string, x, y Value, okx, oky bool) error {
 	var wrongVal Value
 	switch {
 	case oky:

--- a/runtime/comp.go
+++ b/runtime/comp.go
@@ -1,5 +1,7 @@
 package runtime
 
+import "fmt"
+
 // RawEqual returns two values.  The second one is true if raw equality makes
 // sense for x and y.  The first one returns whether x and y are raw equal.
 func RawEqual(x, y Value) (bool, bool) {
@@ -186,5 +188,5 @@ func le(t *Thread, x, y Value) (bool, error) {
 }
 
 func compareError(x, y Value) error {
-	return NewErrorF("attempt to compare a %s value with a %s value", x.CustomTypeName(), y.CustomTypeName())
+	return fmt.Errorf("attempt to compare a %s value with a %s value", x.CustomTypeName(), y.CustomTypeName())
 }

--- a/runtime/comp.go
+++ b/runtime/comp.go
@@ -86,7 +86,7 @@ func equalIntAndFloat(n int64, f float64) bool {
 	return float64(nf) == f && nf == n
 }
 
-func eq(t *Thread, x, y Value) (bool, *Error) {
+func eq(t *Thread, x, y Value) (bool, error) {
 	if res, ok := RawEqual(x, y); ok {
 		return res, nil
 	}
@@ -107,7 +107,7 @@ func eq(t *Thread, x, y Value) (bool, *Error) {
 
 // Lt returns whether x < y is true (and an error if it's not possible to
 // compare them).
-func Lt(t *Thread, x, y Value) (bool, *Error) {
+func Lt(t *Thread, x, y Value) (bool, error) {
 	lt, ok := isLessThan(x, y)
 	if ok {
 		return lt, nil
@@ -156,7 +156,7 @@ func leFloatAndInt(f float64, n int64) bool {
 	return f <= float64(n)
 }
 
-func le(t *Thread, x, y Value) (bool, *Error) {
+func le(t *Thread, x, y Value) (bool, error) {
 	switch x.NumberType() {
 	case IntType:
 		switch y.NumberType() {
@@ -185,6 +185,6 @@ func le(t *Thread, x, y Value) (bool, *Error) {
 	return false, compareError(x, y)
 }
 
-func compareError(x, y Value) *Error {
+func compareError(x, y Value) error {
 	return NewErrorF("attempt to compare a %s value with a %s value", x.CustomTypeName(), y.CustomTypeName())
 }

--- a/runtime/cont.go
+++ b/runtime/cont.go
@@ -21,7 +21,7 @@ type Cont interface {
 
 	// RunInThread runs the continuation in the given thread, returning either
 	// the next continuation to be run or an error.
-	RunInThread(*Thread) (Cont, *Error)
+	RunInThread(*Thread) (Cont, error)
 
 	// Next() returns the continuation that follows after this one (could be
 	// e.g. the caller).
@@ -53,7 +53,7 @@ func (r *Runtime) Push1(c Cont, v Value) {
 // PushIoError is a convenience method that translates ioErr to a value if
 // appropriated and pushes that value to c, else returns an error.  It is useful
 // because a number of Go IO errors are considered regular return values by Lua.
-func (r *Runtime) PushIoError(c Cont, ioErr error) *Error {
+func (r *Runtime) PushIoError(c Cont, ioErr error) error {
 	// It is not specified in the Lua docs, but the test suite expects an
 	// errno as the third value returned in case of an error.  I'm not sure
 	// the conversion to syscall.Errno is future-proof though?
@@ -77,7 +77,7 @@ func (r *Runtime) PushIoError(c Cont, ioErr error) *Error {
 
 // ProcessIoError is like PushIoError but its signature makes it convenient to
 // use in a return statement from a GoFunc implementation.
-func (r *Runtime) ProcessIoError(c Cont, ioErr error) (Cont, *Error) {
+func (r *Runtime) ProcessIoError(c Cont, ioErr error) (Cont, error) {
 	if err := r.PushIoError(c, ioErr); err != nil {
 		return nil, err
 	}

--- a/runtime/cont.go
+++ b/runtime/cont.go
@@ -65,7 +65,7 @@ func (r *Runtime) PushIoError(c Cont, ioErr error) error {
 	case *os.LinkError:
 		err = tErr.Unwrap()
 	default:
-		return NewErrorE(ioErr)
+		return ioErr
 	}
 	r.Push1(c, NilValue)
 	r.Push1(c, StringValue(ioErr.Error()))

--- a/runtime/debughooks.go
+++ b/runtime/debughooks.go
@@ -32,7 +32,7 @@ type DebugHooks struct {
 	Hook           Value          // The hook callback
 }
 
-func (h *DebugHooks) callHook(t *Thread, c Cont, args ...Value) *Error {
+func (h *DebugHooks) callHook(t *Thread, c Cont, args ...Value) error {
 	if h.DebugHookFlags&hookFlagInHook != 0 || c == nil {
 		return nil
 	}
@@ -59,7 +59,7 @@ var (
 )
 
 // Important for this function to inline.
-func (h *DebugHooks) triggerCall(t *Thread, c Cont) *Error {
+func (h *DebugHooks) triggerCall(t *Thread, c Cont) error {
 	if h.DebugHookFlags&HookFlagCall == 0 {
 		return nil
 	}
@@ -67,7 +67,7 @@ func (h *DebugHooks) triggerCall(t *Thread, c Cont) *Error {
 }
 
 // Important for this function to inline.
-func (h *DebugHooks) triggerTailCall(t *Thread, c Cont) *Error {
+func (h *DebugHooks) triggerTailCall(t *Thread, c Cont) error {
 	if h.DebugHookFlags&HookFlagCall == 0 {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (h *DebugHooks) triggerTailCall(t *Thread, c Cont) *Error {
 }
 
 // Important for this function to inline.
-func (h *DebugHooks) triggerReturn(t *Thread, c Cont) *Error {
+func (h *DebugHooks) triggerReturn(t *Thread, c Cont) error {
 	if h.DebugHookFlags&HookFlagReturn == 0 {
 		return nil
 	}
@@ -83,7 +83,7 @@ func (h *DebugHooks) triggerReturn(t *Thread, c Cont) *Error {
 }
 
 // Important for this function to inline.
-func (h *DebugHooks) triggerLine(t *Thread, c Cont, l int32) *Error {
+func (h *DebugHooks) triggerLine(t *Thread, c Cont, l int32) error {
 	if h.DebugHookFlags&HookFlagLine == 0 || l <= 0 {
 		return nil
 	}

--- a/runtime/error.go
+++ b/runtime/error.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -42,15 +43,51 @@ func NewErrorF(msg string, args ...interface{}) *Error {
 	return NewErrorS(fmt.Sprintf(msg, args...))
 }
 
-// AddContext sets the lineno / source fields of the error if not already set.
-func (e *Error) AddContext(c Cont, depth int) {
-	if e.lineno != 0 || e.handled {
-		return
+// AsError check if err can be converted to an *Error and returns that if
+// successful.
+func AsError(err error) (rtErr *Error, ok bool) {
+	ok = errors.As(err, &rtErr)
+	return
+}
+
+// ToError turns err into an *Error instance.
+func ToError(err error) *Error {
+	if err == nil {
+		return nil
 	}
-	e.lineno = -1
-	e.source = "?"
+	rtErr, ok := AsError(err)
+	if ok {
+		return rtErr
+	}
+	return NewErrorE(err)
+}
+
+// ErrorValue extracts a Value from err.  If err is an *Error then it returns
+// its Value(), otherwise it builds a Value from the error string.
+func ErrorValue(err error) Value {
+	if err == nil {
+		return NilValue
+	}
+	rtErr, ok := AsError(err)
+	if ok {
+		return rtErr.Value()
+	}
+	return StringValue(err.Error())
+}
+
+// AddContext returns a new error with the lineno / source fields set if not
+// already set.
+func (e *Error) AddContext(c Cont, depth int) *Error {
+	if e.lineno != 0 || e.handled {
+		return e
+	}
+	e = &Error{
+		lineno:  -1,
+		source:  "?",
+		message: e.message,
+	}
 	if depth == 0 {
-		return
+		return e
 	}
 	if depth > 0 {
 		for depth > 1 && c != nil {
@@ -66,11 +103,11 @@ func (e *Error) AddContext(c Cont, depth int) {
 		}
 	}
 	if c == nil {
-		return
+		return e
 	}
 	info := c.DebugInfo()
 	if info == nil {
-		return
+		return e
 	}
 	if info.CurrentLine != 0 {
 		e.lineno = int(info.CurrentLine)
@@ -80,6 +117,7 @@ func (e *Error) AddContext(c Cont, depth int) {
 	if ok && e.lineno > 0 {
 		e.message = StringValue(fmt.Sprintf("%s:%d: %s", e.source, e.lineno, s))
 	}
+	return e
 }
 
 // Value returns the message of the error (which can be any Lua Value).

--- a/runtime/error.go
+++ b/runtime/error.go
@@ -26,17 +26,6 @@ func newHandledError(message Value) *Error {
 	return &Error{message: message, handled: true}
 }
 
-// NewErrorS returns a new error with a string message and no context.
-func NewErrorS(msg string) *Error {
-	return NewError(StringValue(msg))
-}
-
-// NewErrorF returns a new error with a string message (obtained by calling
-// fmt.Sprintf on the arguments) and no context.
-func NewErrorF(msg string, args ...interface{}) *Error {
-	return NewErrorS(fmt.Sprintf(msg, args...))
-}
-
 // AsError check if err can be converted to an *Error and returns that if
 // successful.
 func AsError(err error) (rtErr *Error, ok bool) {
@@ -53,7 +42,7 @@ func ToError(err error) *Error {
 	if ok {
 		return rtErr
 	}
-	return NewErrorS(err.Error())
+	return NewError(StringValue(err.Error()))
 }
 
 // ErrorValue extracts a Value from err.  If err is an *Error then it returns

--- a/runtime/error.go
+++ b/runtime/error.go
@@ -31,12 +31,6 @@ func NewErrorS(msg string) *Error {
 	return NewError(StringValue(msg))
 }
 
-// NewErrorE returns a new error with a string message (the error message) and
-// no context.
-func NewErrorE(e error) *Error {
-	return NewErrorS(e.Error())
-}
-
 // NewErrorF returns a new error with a string message (obtained by calling
 // fmt.Sprintf on the arguments) and no context.
 func NewErrorF(msg string, args ...interface{}) *Error {
@@ -59,7 +53,7 @@ func ToError(err error) *Error {
 	if ok {
 		return rtErr
 	}
-	return NewErrorE(err)
+	return NewErrorS(err.Error())
 }
 
 // ErrorValue extracts a Value from err.  If err is an *Error then it returns

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -1,0 +1,83 @@
+package runtime
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestAsError(t *testing.T) {
+	tests := []struct {
+		name      string
+		arg       error
+		wantRtErr *Error
+		wantOk    bool
+	}{
+		{
+			name:      "nil",
+			arg:       nil,
+			wantRtErr: nil,
+			wantOk:    false,
+		},
+		{
+			name:      "*Error",
+			arg:       NewErrorS("hello"),
+			wantRtErr: NewErrorS("hello"),
+			wantOk:    true,
+		},
+		{
+			name:      "string error",
+			arg:       errors.New("hello"),
+			wantRtErr: nil,
+			wantOk:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRtErr, gotOk := AsError(tt.arg)
+			if !reflect.DeepEqual(gotRtErr, tt.wantRtErr) {
+				t.Errorf("AsError() gotRtErr = %v, want %v", gotRtErr, tt.wantRtErr)
+			}
+			if gotOk != tt.wantOk {
+				t.Errorf("AsError() gotOk = %v, want %v", gotOk, tt.wantOk)
+			}
+		})
+	}
+}
+
+func TestToError(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  error
+		want *Error
+	}{
+		{
+			name: "nil",
+			arg:  nil,
+			want: nil,
+		},
+		{
+			name: "nil *Error",
+			arg:  (*Error)(nil),
+			want: nil,
+		},
+		{
+			name: "non nil *Error",
+			arg:  NewErrorS("hello"),
+			want: NewErrorS("hello"),
+		},
+		{
+			name: "string error",
+			arg:  errors.New("hi"),
+			want: NewErrorS("hi"),
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToError(tt.arg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/runtime/error_test.go
+++ b/runtime/error_test.go
@@ -21,8 +21,8 @@ func TestAsError(t *testing.T) {
 		},
 		{
 			name:      "*Error",
-			arg:       NewErrorS("hello"),
-			wantRtErr: NewErrorS("hello"),
+			arg:       NewError(StringValue("hello")),
+			wantRtErr: NewError(StringValue("hello")),
 			wantOk:    true,
 		},
 		{
@@ -63,13 +63,13 @@ func TestToError(t *testing.T) {
 		},
 		{
 			name: "non nil *Error",
-			arg:  NewErrorS("hello"),
-			want: NewErrorS("hello"),
+			arg:  errors.New("hello"),
+			want: NewError(StringValue("hello")),
 		},
 		{
 			name: "string error",
 			arg:  errors.New("hi"),
-			want: NewErrorS("hi"),
+			want: NewError(StringValue("hi")),
 		},
 		// TODO: Add test cases.
 	}

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "unsafe"
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+)
 
 // GoCont implements Cont for functions written in Go.
 type GoCont struct {
@@ -94,7 +98,7 @@ func (c *GoCont) RunInThread(t *Thread) (next Cont, err error) {
 	defer func() { t.goFunctionCallDepth-- }()
 
 	if t.goFunctionCallDepth > maxGoFunctionCallDepth {
-		return nil, NewErrorS("stack overflow")
+		return nil, errors.New("stack overflow")
 	}
 	next, err = c.f(t, c)
 	_ = t.triggerReturn(t, c)
@@ -164,7 +168,7 @@ func (c *GoCont) Etc() []Value {
 // one arg.
 func (c *GoCont) Check1Arg() error {
 	if c.nArgs == 0 {
-		return NewErrorS("bad argument #1 (value needed)")
+		return errors.New("bad argument #1 (value needed)")
 	}
 	return nil
 }
@@ -173,7 +177,7 @@ func (c *GoCont) Check1Arg() error {
 // n args.
 func (c *GoCont) CheckNArgs(n int) error {
 	if c.nArgs < n {
-		return NewErrorF("%d arguments needed", n)
+		return fmt.Errorf("%d arguments needed", n)
 	}
 	return nil
 }
@@ -183,7 +187,7 @@ func (c *GoCont) CheckNArgs(n int) error {
 func (c *GoCont) StringArg(n int) (string, error) {
 	s, ok := c.Arg(n).TryString()
 	if !ok {
-		return "", NewErrorF("#%d must be a string", n+1)
+		return "", fmt.Errorf("#%d must be a string", n+1)
 	}
 	return s, nil
 }
@@ -197,7 +201,7 @@ func (c *GoCont) BoolArg(n int) (bool, error) {
 	}
 	b, ok := arg.TryBool()
 	if !ok {
-		return false, NewErrorF("#%d must be a boolean", n+1)
+		return false, fmt.Errorf("#%d must be a boolean", n+1)
 	}
 	return b, nil
 }
@@ -207,7 +211,7 @@ func (c *GoCont) BoolArg(n int) (bool, error) {
 func (c *GoCont) CallableArg(n int) (Callable, error) {
 	f, ok := c.Arg(n).TryCallable()
 	if !ok {
-		return nil, NewErrorF("#%d must be a callable", n+1)
+		return nil, fmt.Errorf("#%d must be a callable", n+1)
 	}
 	return f, nil
 }
@@ -217,7 +221,7 @@ func (c *GoCont) CallableArg(n int) (Callable, error) {
 func (c *GoCont) ClosureArg(n int) (*Closure, error) {
 	f, ok := c.Arg(n).TryClosure()
 	if !ok {
-		return nil, NewErrorF("#%d must be a lua function", n+1)
+		return nil, fmt.Errorf("#%d must be a lua function", n+1)
 	}
 	return f, nil
 }
@@ -227,7 +231,7 @@ func (c *GoCont) ClosureArg(n int) (*Closure, error) {
 func (c *GoCont) ThreadArg(n int) (*Thread, error) {
 	t, ok := c.Arg(n).TryThread()
 	if !ok {
-		return nil, NewErrorF("#%d must be a thread", n+1)
+		return nil, fmt.Errorf("#%d must be a thread", n+1)
 	}
 	return t, nil
 }
@@ -237,7 +241,7 @@ func (c *GoCont) ThreadArg(n int) (*Thread, error) {
 func (c *GoCont) IntArg(n int) (int64, error) {
 	i, ok := ToInt(c.Arg(n))
 	if !ok {
-		return 0, NewErrorF("#%d must be an integer", n+1)
+		return 0, fmt.Errorf("#%d must be an integer", n+1)
 	}
 	return i, nil
 }
@@ -247,7 +251,7 @@ func (c *GoCont) IntArg(n int) (int64, error) {
 func (c *GoCont) FloatArg(n int) (float64, error) {
 	x, ok := ToFloat(c.Arg(n))
 	if !ok {
-		return 0, NewErrorF("#%d must be a number", n+1)
+		return 0, fmt.Errorf("#%d must be a number", n+1)
 	}
 	return x, nil
 }
@@ -257,7 +261,7 @@ func (c *GoCont) FloatArg(n int) (float64, error) {
 func (c *GoCont) TableArg(n int) (*Table, error) {
 	t, ok := c.Arg(n).TryTable()
 	if !ok {
-		return nil, NewErrorF("#%d must be a table", n+1)
+		return nil, fmt.Errorf("#%d must be a table", n+1)
 	}
 	return t, nil
 }
@@ -267,7 +271,7 @@ func (c *GoCont) TableArg(n int) (*Table, error) {
 func (c *GoCont) UserDataArg(n int) (*UserData, error) {
 	t, ok := c.Arg(n).TryUserData()
 	if !ok {
-		return nil, NewErrorF("#%d must be userdata", n+1)
+		return nil, fmt.Errorf("#%d must be userdata", n+1)
 	}
 	return t, nil
 }

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -84,7 +84,7 @@ FillEtc:
 }
 
 // RunInThread implements Cont.RunInThread.
-func (c *GoCont) RunInThread(t *Thread) (next Cont, err *Error) {
+func (c *GoCont) RunInThread(t *Thread) (next Cont, err error) {
 	if err := t.CheckRequiredFlags(c.safetyFlags); err != nil {
 		return nil, err
 	}
@@ -160,18 +160,18 @@ func (c *GoCont) Etc() []Value {
 	return *c.etc
 }
 
-// Check1Arg returns a non-nil *Error if the continuation doesn't have at least
+// Check1Arg returns a non-nil error if the continuation doesn't have at least
 // one arg.
-func (c *GoCont) Check1Arg() *Error {
+func (c *GoCont) Check1Arg() error {
 	if c.nArgs == 0 {
 		return NewErrorS("bad argument #1 (value needed)")
 	}
 	return nil
 }
 
-// CheckNArgs returns a non-nil *Error if the continuation doesn't have at least
+// CheckNArgs returns a non-nil error if the continuation doesn't have at least
 // n args.
-func (c *GoCont) CheckNArgs(n int) *Error {
+func (c *GoCont) CheckNArgs(n int) error {
 	if c.nArgs < n {
 		return NewErrorF("%d arguments needed", n)
 	}
@@ -179,8 +179,8 @@ func (c *GoCont) CheckNArgs(n int) *Error {
 }
 
 // StringArg returns the n-th argument as a string if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) StringArg(n int) (string, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) StringArg(n int) (string, error) {
 	s, ok := c.Arg(n).TryString()
 	if !ok {
 		return "", NewErrorF("#%d must be a string", n+1)
@@ -189,8 +189,8 @@ func (c *GoCont) StringArg(n int) (string, *Error) {
 }
 
 // BoolArg returns the n-th argument as a string if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) BoolArg(n int) (bool, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) BoolArg(n int) (bool, error) {
 	arg := c.Arg(n)
 	if arg.IsNil() {
 		return false, nil
@@ -203,8 +203,8 @@ func (c *GoCont) BoolArg(n int) (bool, *Error) {
 }
 
 // CallableArg returns the n-th argument as a callable if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) CallableArg(n int) (Callable, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) CallableArg(n int) (Callable, error) {
 	f, ok := c.Arg(n).TryCallable()
 	if !ok {
 		return nil, NewErrorF("#%d must be a callable", n+1)
@@ -213,8 +213,8 @@ func (c *GoCont) CallableArg(n int) (Callable, *Error) {
 }
 
 // ClosureArg returns the n-th argument as a closure if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) ClosureArg(n int) (*Closure, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) ClosureArg(n int) (*Closure, error) {
 	f, ok := c.Arg(n).TryClosure()
 	if !ok {
 		return nil, NewErrorF("#%d must be a lua function", n+1)
@@ -223,8 +223,8 @@ func (c *GoCont) ClosureArg(n int) (*Closure, *Error) {
 }
 
 // ThreadArg returns the n-th argument as a thread if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) ThreadArg(n int) (*Thread, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) ThreadArg(n int) (*Thread, error) {
 	t, ok := c.Arg(n).TryThread()
 	if !ok {
 		return nil, NewErrorF("#%d must be a thread", n+1)
@@ -233,8 +233,8 @@ func (c *GoCont) ThreadArg(n int) (*Thread, *Error) {
 }
 
 // IntArg returns the n-th argument as an Int if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) IntArg(n int) (int64, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) IntArg(n int) (int64, error) {
 	i, ok := ToInt(c.Arg(n))
 	if !ok {
 		return 0, NewErrorF("#%d must be an integer", n+1)
@@ -243,8 +243,8 @@ func (c *GoCont) IntArg(n int) (int64, *Error) {
 }
 
 // FloatArg returns the n-th argument as a Float if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) FloatArg(n int) (float64, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) FloatArg(n int) (float64, error) {
 	x, ok := ToFloat(c.Arg(n))
 	if !ok {
 		return 0, NewErrorF("#%d must be a number", n+1)
@@ -253,8 +253,8 @@ func (c *GoCont) FloatArg(n int) (float64, *Error) {
 }
 
 // TableArg returns the n-th argument as a table if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) TableArg(n int) (*Table, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) TableArg(n int) (*Table, error) {
 	t, ok := c.Arg(n).TryTable()
 	if !ok {
 		return nil, NewErrorF("#%d must be a table", n+1)
@@ -263,8 +263,8 @@ func (c *GoCont) TableArg(n int) (*Table, *Error) {
 }
 
 // UserDataArg returns the n-th argument as a UserData if possible, otherwise a
-// non-nil *Error.  No range check!
-func (c *GoCont) UserDataArg(n int) (*UserData, *Error) {
+// non-nil error.  No range check!
+func (c *GoCont) UserDataArg(n int) (*UserData, error) {
 	t, ok := c.Arg(n).TryUserData()
 	if !ok {
 		return nil, NewErrorF("#%d must be userdata", n+1)

--- a/runtime/gofunction.go
+++ b/runtime/gofunction.go
@@ -1,8 +1,10 @@
 package runtime
 
+type GoFunctionFunc func(*Thread, *GoCont) (Cont, error)
+
 // A GoFunction is a callable value implemented by a native Go function.
 type GoFunction struct {
-	f           func(*Thread, *GoCont) (Cont, *Error)
+	f           GoFunctionFunc
 	safetyFlags ComplianceFlags
 	name        string
 	nArgs       int
@@ -12,7 +14,7 @@ type GoFunction struct {
 var _ Callable = (*GoFunction)(nil)
 
 // NewGoFunction returns a new GoFunction.
-func NewGoFunction(f func(*Thread, *GoCont) (Cont, *Error), name string, nArgs int, hasEtc bool) *GoFunction {
+func NewGoFunction(f GoFunctionFunc, name string, nArgs int, hasEtc bool) *GoFunction {
 	return &GoFunction{
 		f:      f,
 		name:   name,

--- a/runtime/lib.go
+++ b/runtime/lib.go
@@ -55,11 +55,11 @@ func Index(t *Thread, coll Value, k Value) (Value, error) {
 			return res.Get(0), nil
 		}
 	}
-	return NilValue, NewErrorF("'__index' chain too long; possible loop")
+	return NilValue, fmt.Errorf("'__index' chain too long; possible loop")
 }
 
 func indexError(coll Value) error {
-	return NewErrorF("attempt to index a %s value", coll.CustomTypeName())
+	return fmt.Errorf("attempt to index a %s value", coll.CustomTypeName())
 }
 
 // SetIndex sets the item in a collection for the given key, using the
@@ -67,7 +67,7 @@ func indexError(coll Value) error {
 // doesn't return an error.
 func SetIndex(t *Thread, coll Value, idx Value, val Value) error {
 	if idx.IsNil() {
-		return NewErrorS("index is nil")
+		return errors.New("index is nil")
 	}
 	for i := 0; i < maxIndexChainLength; i++ {
 		t.RequireCPU(1)
@@ -92,7 +92,7 @@ func SetIndex(t *Thread, coll Value, idx Value, val Value) error {
 			return Call(t, metaNewIndex, []Value{coll, idx, val}, NewTermination(t.CurrentCont(), nil, nil))
 		}
 	}
-	return NewErrorF("'__newindex' chain too long; possible loop")
+	return fmt.Errorf("'__newindex' chain too long; possible loop")
 }
 
 // Truth returns true if v is neither nil nor a false boolean.
@@ -123,7 +123,7 @@ func Continue(t *Thread, f Value, next Cont) (Cont, error) {
 	}
 	cont, err, ok := metacont(t, f, "__call", next)
 	if !ok {
-		return nil, NewErrorF("attempt to call a %s value", f.CustomTypeName())
+		return nil, fmt.Errorf("attempt to call a %s value", f.CustomTypeName())
 	}
 	if cont != nil {
 		t.Push1(cont, f)
@@ -135,7 +135,7 @@ func Continue(t *Thread, f Value, next Cont) (Cont, error) {
 // the metamethod '__call' if f is not callable.
 func Call(t *Thread, f Value, args []Value, next Cont) error {
 	if f.IsNil() {
-		return NewErrorS("attempt to call a nil value")
+		return errors.New("attempt to call a nil value")
 	}
 	callable, ok := f.TryCallable()
 	if ok {
@@ -145,7 +145,7 @@ func Call(t *Thread, f Value, args []Value, next Cont) error {
 	if ok {
 		return err
 	}
-	return NewErrorF("attempt to call a %s value", f.CustomTypeName())
+	return fmt.Errorf("attempt to call a %s value", f.CustomTypeName())
 }
 
 // Call1 is a convenience method that calls f with arguments args and returns
@@ -183,9 +183,9 @@ func concatError(x, y Value, okx, oky bool) error {
 	case okx:
 		wrongVal = y
 	default:
-		return NewErrorF("attempt to concatenate a %s value with a %s value", x.CustomTypeName(), y.CustomTypeName())
+		return fmt.Errorf("attempt to concatenate a %s value with a %s value", x.CustomTypeName(), y.CustomTypeName())
 	}
-	return NewErrorF("attempt to concatenate a %s value", wrongVal.CustomTypeName())
+	return fmt.Errorf("attempt to concatenate a %s value", wrongVal.CustomTypeName())
 }
 
 // IntLen returns the length of v as an int64, possibly calling the '__len'
@@ -202,7 +202,7 @@ func IntLen(t *Thread, v Value) (int64, error) {
 		}
 		l, ok := ToInt(res.Get(0))
 		if !ok {
-			err = NewErrorS("len should return an integer")
+			err = errors.New("len should return an integer")
 		}
 		return l, err
 	}
@@ -232,7 +232,7 @@ func Len(t *Thread, v Value) (Value, error) {
 }
 
 func lenError(x Value) error {
-	return NewErrorF("attempt to get length of a %s value", x.CustomTypeName())
+	return fmt.Errorf("attempt to get length of a %s value", x.CustomTypeName())
 }
 
 // SetEnv sets the item in the table t for a string key.  Useful when writing

--- a/runtime/lib.go
+++ b/runtime/lib.go
@@ -73,7 +73,7 @@ func SetIndex(t *Thread, coll Value, idx Value, val Value) error {
 		t.RequireCPU(1)
 		tbl, isTable := coll.TryTable()
 		if isTable && idx.IsNaN() {
-			return NewErrorE(errTableIndexIsNaN)
+			return errTableIndexIsNaN
 		}
 		if isTable && tbl.Reset(idx, val) {
 			return nil

--- a/runtime/lib.go
+++ b/runtime/lib.go
@@ -29,7 +29,7 @@ const maxIndexChainLength = 100
 // Index returns the item in a collection for the given key k, using the
 // '__index' metamethod if appropriate.
 // Index always consumes CPU.
-func Index(t *Thread, coll Value, k Value) (Value, *Error) {
+func Index(t *Thread, coll Value, k Value) (Value, error) {
 	for i := 0; i < maxIndexChainLength; i++ {
 		t.RequireCPU(1)
 		tbl, ok := coll.TryTable()
@@ -58,14 +58,14 @@ func Index(t *Thread, coll Value, k Value) (Value, *Error) {
 	return NilValue, NewErrorF("'__index' chain too long; possible loop")
 }
 
-func indexError(coll Value) *Error {
+func indexError(coll Value) error {
 	return NewErrorF("attempt to index a %s value", coll.CustomTypeName())
 }
 
 // SetIndex sets the item in a collection for the given key, using the
 // '__newindex' metamethod if appropriate.  SetIndex always consumes CPU if it
 // doesn't return an error.
-func SetIndex(t *Thread, coll Value, idx Value, val Value) *Error {
+func SetIndex(t *Thread, coll Value, idx Value, val Value) error {
 	if idx.IsNil() {
 		return NewErrorS("index is nil")
 	}
@@ -106,7 +106,7 @@ func Truth(v Value) bool {
 
 // Metacall calls the metamethod called method on obj with the given arguments
 // args, pushing the result to the continuation next.
-func Metacall(t *Thread, obj Value, method string, args []Value, next Cont) (*Error, bool) {
+func Metacall(t *Thread, obj Value, method string, args []Value, next Cont) (error, bool) {
 	if f := t.metaGetS(obj, method); !f.IsNil() {
 		return Call(t, f, args, next), true
 	}
@@ -116,7 +116,7 @@ func Metacall(t *Thread, obj Value, method string, args []Value, next Cont) (*Er
 // Continue tries to continue the value f or else use its '__call'
 // metamethod and returns the continuations that needs to be run to get the
 // results.
-func Continue(t *Thread, f Value, next Cont) (Cont, *Error) {
+func Continue(t *Thread, f Value, next Cont) (Cont, error) {
 	callable, ok := f.TryCallable()
 	if ok {
 		return callable.Continuation(t, next), nil
@@ -133,7 +133,7 @@ func Continue(t *Thread, f Value, next Cont) (Cont, *Error) {
 
 // Call calls f with arguments args, pushing the results on next.  It may use
 // the metamethod '__call' if f is not callable.
-func Call(t *Thread, f Value, args []Value, next Cont) *Error {
+func Call(t *Thread, f Value, args []Value, next Cont) error {
 	if f.IsNil() {
 		return NewErrorS("attempt to call a nil value")
 	}
@@ -150,7 +150,7 @@ func Call(t *Thread, f Value, args []Value, next Cont) *Error {
 
 // Call1 is a convenience method that calls f with arguments args and returns
 // exactly one value.
-func Call1(t *Thread, f Value, args ...Value) (Value, *Error) {
+func Call1(t *Thread, f Value, args ...Value) (Value, error) {
 	term := NewTerminationWith(t.CurrentCont(), 1, false)
 	if err := Call(t, f, args, term); err != nil {
 		return NilValue, err
@@ -159,7 +159,7 @@ func Call1(t *Thread, f Value, args ...Value) (Value, *Error) {
 }
 
 // Concat returns x .. y, possibly calling the '__concat' metamethod.
-func Concat(t *Thread, x, y Value) (Value, *Error) {
+func Concat(t *Thread, x, y Value) (Value, error) {
 	var sx, sy string
 	var okx, oky bool
 	if sx, okx = x.ToString(); okx {
@@ -175,7 +175,7 @@ func Concat(t *Thread, x, y Value) (Value, *Error) {
 	return NilValue, concatError(x, y, okx, oky)
 }
 
-func concatError(x, y Value, okx, oky bool) *Error {
+func concatError(x, y Value, okx, oky bool) error {
 	var wrongVal Value
 	switch {
 	case oky:
@@ -190,7 +190,7 @@ func concatError(x, y Value, okx, oky bool) *Error {
 
 // IntLen returns the length of v as an int64, possibly calling the '__len'
 // metamethod.  This is an optimization of Len for an integer output.
-func IntLen(t *Thread, v Value) (int64, *Error) {
+func IntLen(t *Thread, v Value) (int64, error) {
 	if s, ok := v.TryString(); ok {
 		return int64(len(s)), nil
 	}
@@ -213,7 +213,7 @@ func IntLen(t *Thread, v Value) (int64, *Error) {
 }
 
 // Len returns the length of v, possibly calling the '__len' metamethod.
-func Len(t *Thread, v Value) (Value, *Error) {
+func Len(t *Thread, v Value) (Value, error) {
 	if s, ok := v.TryString(); ok {
 		return IntValue(int64(len(s))), nil
 	}
@@ -231,7 +231,7 @@ func Len(t *Thread, v Value) (Value, *Error) {
 	return NilValue, lenError(v)
 }
 
-func lenError(x Value) *Error {
+func lenError(x Value) error {
 	return NewErrorF("attempt to get length of a %s value", x.CustomTypeName())
 }
 
@@ -243,7 +243,7 @@ func (r *Runtime) SetEnv(t *Table, name string, v Value) {
 
 // SetEnvGoFunc sets the item in the table t for a string key to be a GoFunction
 // defined by f.  Useful when writing libraries
-func (r *Runtime) SetEnvGoFunc(t *Table, name string, f func(*Thread, *GoCont) (Cont, *Error), nArgs int, hasEtc bool) *GoFunction {
+func (r *Runtime) SetEnvGoFunc(t *Table, name string, f GoFunctionFunc, nArgs int, hasEtc bool) *GoFunction {
 	gof := &GoFunction{
 		f:      f,
 		name:   name,
@@ -267,8 +267,8 @@ func (r *Runtime) ParseLuaChunk(name string, source []byte, scannerOptions ...sc
 	*stat, err = parsing.ParseChunk(s)
 	if err != nil {
 		r.ReleaseMem(statSize)
-		parseErr, ok := err.(parsing.Error)
-		if !ok {
+		var parseErr parsing.Error
+		if !errors.As(err, &parseErr) {
 			return nil, 0, err
 		}
 		return nil, 0, NewSyntaxError(name, parseErr)
@@ -288,8 +288,8 @@ func (r *Runtime) ParseLuaExp(name string, source []byte, scannerOptions ...scan
 	exp, err := parsing.ParseExp(s)
 	if err != nil {
 		r.ReleaseMem(statSize)
-		parseErr, ok := err.(parsing.Error)
-		if !ok {
+		var parseErr parsing.Error
+		if !errors.As(err, &parseErr) {
 			return nil, 0, err
 		}
 		return nil, 0, NewSyntaxError(name, parseErr)
@@ -353,8 +353,8 @@ func (r *Runtime) CompileLuaChunkOrExp(name string, source []byte, scannerOption
 	}
 	if expErr != nil && statErr != nil {
 		// If parsing as expression or chunk failed, then try to return the error that showed the most parsing
-		expSyntaxErr, okExp := expErr.(*SyntaxError)
-		statSyntaxErr, okStat := statErr.(*SyntaxError)
+		expSyntaxErr, okExp := AsSyntaxError(expErr)
+		statSyntaxErr, okStat := AsSyntaxError(statErr)
 		switch {
 		case !okStat:
 			err = expErr
@@ -465,7 +465,7 @@ func stripFirstLineComment(chunk []byte) ([]byte, bool) {
 	return nil, true
 }
 
-func metacont(t *Thread, obj Value, method string, next Cont) (Cont, *Error, bool) {
+func metacont(t *Thread, obj Value, method string, next Cont) (Cont, error, bool) {
 	f := t.metaGetS(obj, method)
 	if f.IsNil() {
 		return nil, nil, false
@@ -477,7 +477,7 @@ func metacont(t *Thread, obj Value, method string, next Cont) (Cont, *Error, boo
 	return cont, nil, true
 }
 
-func metabin(t *Thread, f string, x Value, y Value) (Value, *Error, bool) {
+func metabin(t *Thread, f string, x Value, y Value) (Value, error, bool) {
 	xy := []Value{x, y}
 	res := NewTerminationWith(t.CurrentCont(), 1, false)
 	err, ok := Metacall(t, x, f, xy, res)
@@ -490,7 +490,7 @@ func metabin(t *Thread, f string, x Value, y Value) (Value, *Error, bool) {
 	return NilValue, nil, false
 }
 
-func metaun(t *Thread, f string, x Value) (Value, *Error, bool) {
+func metaun(t *Thread, f string, x Value) (Value, error, bool) {
 	res := NewTerminationWith(t.CurrentCont(), 1, false)
 	err, ok := Metacall(t, x, f, []Value{x}, res)
 	if ok {

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -103,7 +103,7 @@ func (c *LuaCont) Parent() Cont {
 }
 
 // RunInThread implements Cont.RunInThread.
-func (c *LuaCont) RunInThread(t *Thread) (Cont, *Error) {
+func (c *LuaCont) RunInThread(t *Thread) (Cont, error) {
 	pc := c.pc
 	consts := c.consts
 	lines := c.lines
@@ -131,7 +131,7 @@ RunLoop:
 			x := getReg(regs, cells, opcode.GetB())
 			y := getReg(regs, cells, opcode.GetC())
 			var res Value
-			var err *Error
+			var err error
 			var ok bool
 			switch opcode.GetX() {
 
@@ -276,7 +276,7 @@ RunLoop:
 			dst := opcode.GetA()
 			var res Value
 			var ok bool
-			var err *Error
+			var err error
 			if opcode.HasType4a() {
 				val := getReg(regs, cells, opcode.GetB())
 				switch opcode.GetUnOp() {

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"errors"
+	"fmt"
 	"unsafe"
 
 	"github.com/arnodel/golua/code"
@@ -414,7 +416,7 @@ RunLoop:
 					v := getReg(regs, cells, opcode.GetA())
 					if Truth(v) && t.metaGetS(v, "__close").IsNil() {
 						c.pc = pc
-						return nil, NewErrorS("to be closed value missing a __close metamethod")
+						return nil, errors.New("to be closed value missing a __close metamethod")
 					}
 					t.closeStack.push(v)
 				} else {
@@ -490,7 +492,7 @@ RunLoop:
 					default:
 						role, val = "step", step
 					}
-					return nil, NewErrorF("'for' %s: expected number, got %s", role, val.CustomTypeName())
+					return nil, fmt.Errorf("'for' %s: expected number, got %s", role, val.CustomTypeName())
 				}
 				// Make sure start and step have the same numeric type
 				if tstart != tstep {
@@ -504,7 +506,7 @@ RunLoop:
 				// A 0 step is an error
 				if isZero(step) {
 					c.pc = pc
-					return nil, NewErrorS("'for' step is zero")
+					return nil, errors.New("'for' step is zero")
 				}
 				// Check the loop is not already finished. If so, startReg is
 				// set to nil.

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -65,7 +65,7 @@ func (m *runtimeContextManager) RequiredFlags() ComplianceFlags {
 	return m.requiredFlags
 }
 
-func (m *runtimeContextManager) CheckRequiredFlags(flags ComplianceFlags) *Error {
+func (m *runtimeContextManager) CheckRequiredFlags(flags ComplianceFlags) error {
 	missingFlags := m.requiredFlags &^ flags
 	if missingFlags != 0 {
 		return NewErrorF("missing flags: %s", strings.Join(missingFlags.Names(), " "))

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -68,7 +68,7 @@ func (m *runtimeContextManager) RequiredFlags() ComplianceFlags {
 func (m *runtimeContextManager) CheckRequiredFlags(flags ComplianceFlags) error {
 	missingFlags := m.requiredFlags &^ flags
 	if missingFlags != 0 {
-		return NewErrorF("missing flags: %s", strings.Join(missingFlags.Names(), " "))
+		return fmt.Errorf("missing flags: %s", strings.Join(missingFlags.Names(), " "))
 	}
 	return nil
 }

--- a/runtime/runtimecontextmanager_noquotas.go
+++ b/runtime/runtimecontextmanager_noquotas.go
@@ -39,7 +39,7 @@ func (m *runtimeContextManager) RequiredFlags() (f ComplianceFlags) {
 	return
 }
 
-func (m *runtimeContextManager) CheckRequiredFlags(ComplianceFlags) *Error {
+func (m *runtimeContextManager) CheckRequiredFlags(ComplianceFlags) error {
 	return nil
 }
 
@@ -69,7 +69,7 @@ func (m *runtimeContextManager) PopContext() RuntimeContext {
 	return nil
 }
 
-func (m *runtimeContextManager) CallContext(def RuntimeContextDef, f func() *Error) (ctx RuntimeContext, err *Error) {
+func (m *runtimeContextManager) CallContext(def RuntimeContextDef, f func() error) (ctx RuntimeContext, err error) {
 	m.PushContext(def)
 	defer m.PopContext()
 	return nil, f()

--- a/runtime/syntaxerror.go
+++ b/runtime/syntaxerror.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/arnodel/golua/parsing"
@@ -33,6 +34,11 @@ func (e *SyntaxError) IsUnexpectedEOF() bool {
 }
 
 func ErrorIsUnexpectedEOF(err error) bool {
-	snErr, ok := err.(*SyntaxError)
+	snErr, ok := AsSyntaxError(err)
 	return ok && snErr.IsUnexpectedEOF()
+}
+
+func AsSyntaxError(err error) (snErr *SyntaxError, ok bool) {
+	ok = errors.As(err, &snErr)
+	return
 }

--- a/runtime/termination.go
+++ b/runtime/termination.go
@@ -68,7 +68,7 @@ FillEtc:
 
 // RunInThread implements Cont.RunInThread. A termination exits
 // immediately so it always returns nil.
-func (c *Termination) RunInThread(t *Thread) (Cont, *Error) {
+func (c *Termination) RunInThread(t *Thread) (Cont, error) {
 	return nil, nil
 }
 

--- a/runtime/thread.go
+++ b/runtime/thread.go
@@ -27,7 +27,7 @@ const maxGoFunctionCallDepth = 1000
 // coroutine.close() function).  Other types will cause a panic.
 type valuesError struct {
 	args      []Value     // arguments ot yield or resume
-	err       *Error      // execution error
+	err       error       // execution error
 	exception interface{} // used when the thread should be closed right away
 }
 
@@ -40,8 +40,8 @@ type Thread struct {
 	*Runtime
 	mux         sync.Mutex
 	status      ThreadStatus
-	closeErr    *Error // Error that caused the thread to stop
-	currentCont Cont   // Currently running continuation
+	closeErr    error // Error that caused the thread to stop
+	currentCont Cont  // Currently running continuation
 	resumeCh    chan valuesError
 	caller      *Thread // Who resumed this thread
 
@@ -85,7 +85,7 @@ var errErrorInMessageHandler = StringValue("error in error handling")
 // RunContinuation runs the continuation c in the thread. It keeps running until
 // the next continuation is nil or an error occurs, in which case it returns the
 // error.
-func (t *Thread) RunContinuation(c Cont) (err *Error) {
+func (t *Thread) RunContinuation(c Cont) (err error) {
 	var next Cont
 	var errContCount = 0
 	_ = t.triggerCall(t, c)
@@ -93,21 +93,21 @@ func (t *Thread) RunContinuation(c Cont) (err *Error) {
 		t.currentCont = c
 		next, err = c.RunInThread(t)
 		if err != nil {
-			if err.Handled() {
-				return err
+			rtErr := ToError(err)
+			if rtErr.Handled() {
+				return rtErr
 			}
-			err.AddContext(c, -1)
+			err = rtErr.AddContext(c, -1)
 			errContCount++
 			if t.messageHandler != nil {
 				if errContCount > maxErrorsInMessageHandler {
 					return newHandledError(errErrorInMessageHandler)
 				}
 				next = t.messageHandler.Continuation(t, newMessageHandlerCont(c))
-				next.Push(t.Runtime, err.Value())
 			} else {
 				next = newMessageHandlerCont(c)
-				next.Push(t.Runtime, err.Value())
 			}
+			next.Push(t.Runtime, ErrorValue(err))
 		}
 		c = next
 	}
@@ -131,7 +131,7 @@ func (t *Thread) Start(c Callable) {
 	go func() {
 		var (
 			args []Value
-			err  *Error
+			err  error
 		)
 		// If there was a panic due to an exceeded quota, we need to end the
 		// thread and propagate that panic to the calling thread
@@ -165,7 +165,7 @@ func (t *Thread) Status() ThreadStatus {
 
 // Resume execution of a suspended thread.  Its status switches to
 // running while its caller's status switches to suspended.
-func (t *Thread) Resume(caller *Thread, args []Value) ([]Value, *Error) {
+func (t *Thread) Resume(caller *Thread, args []Value) ([]Value, error) {
 	t.mux.Lock()
 	if t.status != ThreadSuspended {
 		t.mux.Unlock()
@@ -193,7 +193,7 @@ func (t *Thread) Resume(caller *Thread, args []Value) ([]Value, *Error) {
 // suspended or already dead).  The error is non-nil if there was an error in
 // the cleanup process, or if the thread had already stopped with an error
 // previously.
-func (t *Thread) Close(caller *Thread) (bool, *Error) {
+func (t *Thread) Close(caller *Thread) (bool, error) {
 	t.mux.Lock()
 	if t.status != ThreadSuspended {
 		t.mux.Unlock()
@@ -221,7 +221,7 @@ func (t *Thread) Close(caller *Thread) (bool, *Error) {
 
 // Yield to the caller thread.  The yielding thread's status switches to
 // suspended.  The caller's status must be OK.
-func (t *Thread) Yield(args []Value) ([]Value, *Error) {
+func (t *Thread) Yield(args []Value) ([]Value, error) {
 	t.mux.Lock()
 	if t.status != ThreadOK {
 		panic("Thread to yield is not running")
@@ -245,7 +245,7 @@ func (t *Thread) Yield(args []Value) ([]Value, *Error) {
 
 // This turns off the thread, cleaning up its close stack.  The thread must be
 // running.
-func (t *Thread) end(args []Value, err *Error, exception interface{}) {
+func (t *Thread) end(args []Value, err error, exception interface{}) {
 	caller := t.caller
 	t.mux.Lock()
 	caller.mux.Lock()
@@ -266,13 +266,13 @@ func (t *Thread) end(args []Value, err *Error, exception interface{}) {
 	t.ReleaseBytes(2 << 10) // The goroutine will terminate after this
 }
 
-func (t *Thread) call(c Callable, args []Value, next Cont) *Error {
+func (t *Thread) call(c Callable, args []Value, next Cont) error {
 	cont := c.Continuation(t, next)
 	t.Push(cont, args...)
 	return t.RunContinuation(cont)
 }
 
-func (t *Thread) getResumeValues() ([]Value, *Error) {
+func (t *Thread) getResumeValues() ([]Value, error) {
 	res := <-t.resumeCh
 	if res.exception != nil {
 		panic(res.exception)
@@ -280,7 +280,7 @@ func (t *Thread) getResumeValues() ([]Value, *Error) {
 	return res.args, res.err
 }
 
-func (t *Thread) sendResumeValues(args []Value, err *Error, exception interface{}) {
+func (t *Thread) sendResumeValues(args []Value, err error, exception interface{}) {
 	t.resumeCh <- valuesError{args: args, err: err, exception: exception}
 }
 
@@ -297,7 +297,7 @@ func (t *Thread) sendResumeValues(args []Value, err *Error, exception interface{
 // be finalized.
 //
 // See quotas.md for details about this API.
-func (t *Thread) CallContext(def RuntimeContextDef, f func() *Error) (ctx RuntimeContext, err *Error) {
+func (t *Thread) CallContext(def RuntimeContextDef, f func() error) (ctx RuntimeContext, err error) {
 	t.PushContext(def)
 	c, h := t.CurrentCont(), t.closeStack.size()
 	defer func() {
@@ -353,12 +353,12 @@ func (s *closeStack) truncate(h int) {
 
 // Truncate the close stack to size h, calling the __close metamethods in the
 // context of the given continuation c and feeding them with the given error.
-func (t *Thread) cleanupCloseStack(c Cont, h int, err *Error) *Error {
+func (t *Thread) cleanupCloseStack(c Cont, h int, err error) error {
 	closeStack := &t.closeStack
 	for closeStack.size() > h {
 		v, _ := closeStack.pop()
 		if Truth(v) {
-			closeErr, ok := Metacall(t, v, "__close", []Value{v, err.Value()}, NewTerminationWith(c, 0, false))
+			closeErr, ok := Metacall(t, v, "__close", []Value{v, ErrorValue(err)}, NewTerminationWith(c, 0, false))
 			if !ok {
 				return NewErrorS("to be closed value missing a __close metamethod")
 			}
@@ -412,6 +412,6 @@ func (c *messageHandlerCont) PushEtc(r *Runtime, etc []Value) {
 	c.Push(r, etc[0])
 }
 
-func (c *messageHandlerCont) RunInThread(t *Thread) (Cont, *Error) {
+func (c *messageHandlerCont) RunInThread(t *Thread) (Cont, error) {
 	return nil, newHandledError(c.err)
 }

--- a/runtime/thread.go
+++ b/runtime/thread.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"sync"
 	"unsafe"
 )
@@ -171,9 +172,9 @@ func (t *Thread) Resume(caller *Thread, args []Value) ([]Value, error) {
 		t.mux.Unlock()
 		switch t.status {
 		case ThreadDead:
-			return nil, NewErrorS("cannot resume dead thread")
+			return nil, errors.New("cannot resume dead thread")
 		default:
-			return nil, NewErrorS("cannot resume running thread")
+			return nil, errors.New("cannot resume running thread")
 		}
 	}
 	caller.mux.Lock()
@@ -229,7 +230,7 @@ func (t *Thread) Yield(args []Value) ([]Value, error) {
 	caller := t.caller
 	if caller == nil {
 		t.mux.Unlock()
-		return nil, NewErrorS("cannot yield from main thread")
+		return nil, errors.New("cannot yield from main thread")
 	}
 	caller.mux.Lock()
 	if caller.status != ThreadOK {
@@ -360,7 +361,7 @@ func (t *Thread) cleanupCloseStack(c Cont, h int, err error) error {
 		if Truth(v) {
 			closeErr, ok := Metacall(t, v, "__close", []Value{v, ErrorValue(err)}, NewTerminationWith(c, 0, false))
 			if !ok {
-				return NewErrorS("to be closed value missing a __close metamethod")
+				return errors.New("to be closed value missing a __close metamethod")
 			}
 			if closeErr != nil {
 				err = closeErr

--- a/runtime/thread_test.go
+++ b/runtime/thread_test.go
@@ -90,7 +90,7 @@ func TestThread_Yield(t *testing.T) {
 func TestThread_end(t *testing.T) {
 	type args struct {
 		args  []Value
-		err   *Error
+		err   error
 		extra interface{}
 	}
 	quotaErr := ContextTerminationError{message: "boo!"}


### PR DESCRIPTION
Many function signatures in Golua take error arguments or returns errors of the type `*Error`.  This PR changes these to the more idiomatic `error` type.